### PR TITLE
Properly handle case when Selenium server last-version check fails

### DIFF
--- a/src-tests/Console/Command/InstallCommandTest.php
+++ b/src-tests/Console/Command/InstallCommandTest.php
@@ -94,13 +94,61 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0, $this->tester->getStatusCode());
     }
 
+    public function testShouldRequireVersionToBeEnteredIfLastVersionCheckFails()
+    {
+        $this->command->setDownloader($this->getDownloadMock());
+        $fileGetContentsMock = $this->getFunctionMock('Lmc\Steward\Selenium', 'file_get_contents');
+        $fileGetContentsMock->expects($this->any())
+            ->willReturn(false);
+
+        $this->mockUserInput("\n1.33.7");
+
+        $this->tester->execute(
+            ['command' => $this->command->getName()],
+            ['verbosity' => OutputInterface::VERBOSITY_VERBOSE] // to get the file URL output
+        );
+
+        $this->assertContains(
+            'Enter Selenium server version to install: ',
+            $this->tester->getDisplay()
+        );
+        $this->assertContains(
+            ' Please provide version to download (latest version auto-detect failed)',
+            $this->tester->getDisplay()
+        );
+    }
+
     public function testShouldPrintErrorIfDownloadFails()
     {
         $this->command->setDownloader($this->getDownloadMock($expectedFileSize = false));
 
         $this->tester->execute(['command' => $this->command->getName(), 'version' => '6.3.6']);
 
-        $this->assertContains('Error downloading file :-', $this->tester->getDisplay());
+        $this->assertContains('Error downloading file :-(', $this->tester->getDisplay());
+        $this->assertSame(1, $this->tester->getStatusCode());
+    }
+
+    public function testShouldExitInNonInteractiveModeIfLastVersionCheckFailsAndNoVersionWasProvided()
+    {
+        $downloaderMock = $this->getMockBuilder(Downloader::class)
+            ->setConstructorArgs([__DIR__ . '/Fixtures/vendor/bin'])
+            ->getMock();
+
+        $this->command->setDownloader($downloaderMock);
+        $fileGetContentsMock = $this->getFunctionMock('Lmc\Steward\Selenium', 'file_get_contents');
+        $fileGetContentsMock->expects($this->any())
+            ->willReturn(false);
+
+        $this->tester->execute(
+            ['command' => $this->command->getName()],
+            ['interactive' => false, 'verbosity' => OutputInterface::VERBOSITY_VERBOSE]
+        );
+
+        $this->assertEquals(
+            "Please provide version to download (latest version auto-detect failed)\n",
+            $this->tester->getDisplay()
+        );
+
         $this->assertSame(1, $this->tester->getStatusCode());
     }
 

--- a/src-tests/Console/Command/InstallCommandTest.php
+++ b/src-tests/Console/Command/InstallCommandTest.php
@@ -7,6 +7,7 @@ use Lmc\Steward\Console\Event\BasicConsoleEvent;
 use Lmc\Steward\Selenium\Downloader;
 use phpmock\phpunit\PHPMock;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -40,7 +41,8 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
             [
                 'command' => $this->command->getName(),
                 'version' => '6.3.6',
-            ]
+            ],
+            ['verbosity' => OutputInterface::VERBOSITY_VERBOSE] // to get the file URL output
         );
 
         $this->assertContains(
@@ -58,12 +60,12 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
         $this->mockLatestVersionCheck();
         $this->mockUserInput("\n"); // just press enter when asking for version to install to confirm default
 
-        $this->tester->execute(['command' => $this->command->getName()]);
-
-        $this->assertContains(
-            'Enter Selenium server version to install: [5.67.8]',
-            $this->tester->getDisplay()
+        $this->tester->execute(
+            ['command' => $this->command->getName()],
+            ['verbosity' => OutputInterface::VERBOSITY_VERBOSE] // to get the file URL output
         );
+
+        $this->assertContains('Enter Selenium server version to install: [5.67.8]', $this->tester->getDisplay());
 
         // Check latest version was downloaded
         $this->assertContains(
@@ -79,7 +81,10 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
         $this->mockLatestVersionCheck();
         $this->mockUserInput("1.33.7\n");
 
-        $this->tester->execute(['command' => $this->command->getName()]);
+        $this->tester->execute(
+            ['command' => $this->command->getName()],
+            ['verbosity' => OutputInterface::VERBOSITY_VERBOSE] // to get the file URL output
+        );
 
         // Check custom version was downloaded
         $this->assertContains(

--- a/src/Console/Command/InstallCommand.php
+++ b/src/Console/Command/InstallCommand.php
@@ -73,7 +73,7 @@ class InstallCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $verboseOutput = false;
-        if ($input->isInteractive() || $output->isVeryVerbose()) {
+        if ($input->isInteractive() || $output->isVerbose()) {
             $verboseOutput = true;
         }
 
@@ -95,15 +95,18 @@ class InstallCommand extends Command
 
         if ($verboseOutput) {
             $output->writeln(
-                'Steward is now downloading Selenium standalone server...'
-                . (!getenv('JOB_NAME') ? ' Just for you <3!' : '') // in jenkins it is not just for you, sorry
+                sprintf(
+                    '<info>Steward</info> <comment>%s</comment> is now downloading the Selenium standalone server...%s',
+                    $this->getApplication()->getVersion(),
+                    (!getenv('JOB_NAME') ? ' Just for you <fg=red><3</fg=red>!' : '')
+                )
             );
         }
 
         $downloader = $this->getDownloader();
         $downloader->setVersion($version);
 
-        if ($verboseOutput) {
+        if ($output->isVerbose()) {
             $output->writeln(sprintf('Version: %s', $version));
             $output->writeln(sprintf('File URL: %s', $downloader->getFileUrl()));
             $output->writeln(sprintf('Target file path: %s', $downloader->getFilePath()));
@@ -132,7 +135,7 @@ class InstallCommand extends Command
         $downloadedSize = $downloader->download();
 
         if (!$downloadedSize) {
-            $output->writeln('Error downloading file :-(');
+            $output->writeln('<error>Error downloading file :-(</error>');
             return 1;
         }
 

--- a/src/Console/Command/RunTestsCommand.php
+++ b/src/Console/Command/RunTestsCommand.php
@@ -139,8 +139,11 @@ class RunTestsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln(
-            'Steward is running the tests...'
-            . (!getenv('JOB_NAME') ? ' Just for you <3!' : '') // in jenkins it is not just for you, sorry
+            sprintf(
+                '<info>Steward</info> <comment>%s</comment> is running the tests...%s',
+                $this->getApplication()->getVersion(),
+                (!getenv('JOB_NAME') ? ' Just for you <fg=red><3</fg=red>!' : '') // in jenkins it is not just for you
+            )
         );
 
         $output->writeln(sprintf('Browser: %s', $input->getArgument(self::ARGUMENT_BROWSER)));

--- a/src/Selenium/Downloader.php
+++ b/src/Selenium/Downloader.php
@@ -28,7 +28,7 @@ class Downloader
      */
     public static function getLatestVersion()
     {
-        $data = file_get_contents(self::$storageUrl);
+        $data = @file_get_contents(self::$storageUrl);
         if (!$data) {
             return false;
         }


### PR DESCRIPTION
When last-version autodetect fails, require user to define the version-to-download manually.
