### PR TITLE
Embed XSL into results XML file to overcome same origin policy problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet.
+### Changed
+- The `logs/results.xml` could now be also accessed locally (the XSLT is now embedded right into the file, so we don't encounter same-origin policy problems).
 
 ## 1.0.0 - 2015-05-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ The log is printed to the console where you run the `run-tests` command. But thi
 
 So for each testcase there is separate file in JUnit XML format, placed in `logs/` directory. Also screenshots and HTML snapsnots are saved into this directory (they are automatically generated on failed assertion or if some WebDriver command fails).
 
-During the tests execution check file `logs/results.xml` (you must access it through webserver, as the XSLT won't work and you will see plain XML) to see current status of tests.
-
+During the tests execution check file `logs/results.xml` to see current status of tests:
 ![Example output as displayed in logs/results.xml file](https://lmc-eu.github.io/steward/images/results-output-example.png)
 
 ## License

--- a/src/results.xsl
+++ b/src/results.xsl
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="stylesheet">
 
     <xsl:output method="xml" doctype-system="about:legacy-compat" indent="yes" encoding="UTF-8"/>
 
@@ -7,7 +6,7 @@
         <html xmlns="http://www.w3.org/1999/xhtml">
             <head>
                 <title>Steward results</title>
-                <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet"/>
+                <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet"/>
             </head>
             <body>
                 <div class="container">
@@ -108,7 +107,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <xsl:for-each select="/testcases/testcase">
+                            <xsl:for-each select="//testcases/testcase">
                                 <tr class="testcase-row">
                                     <td colspan="2">
                                         <xsl:value-of select="@name"/>
@@ -198,8 +197,8 @@
                         </tbody>
                     </table>
                 </div>
-            <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-            <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.3/moment.min.js"></script>
+            <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.3/moment.min.js"></script>
             <script>
                 <![CDATA[
                 $(function () {
@@ -232,6 +231,10 @@
             </script>
             </body>
         </html>
+    </xsl:template>
+
+    <xsl:template match="xsl:stylesheet">
+        <!-- ignore the stylesheet from being processed -->
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
When the results.xml is accessed locally, same-origin policy didn't allow to load the XSLT from other files. Same problem occurs with http address.

Probably the only solution is to embed the XSL stylesheet right into the XML file.

cc @tenerd @dudla @mplmc 
