### PR TITLE
No longer need to use dev-master version of php-webdriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 ### Changed
 - The `logs/results.xml` could now be also accessed locally (the XSLT is now embedded right into the file, so we don't encounter same-origin policy problems).
+- Use tagged version 0.6.0 of [php-webdriver](https://github.com/facebook/php-webdriver)
 
 ## 1.0.0 - 2015-05-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ For latest changes see [CHANGELOG.md](CHANGELOG.md) file. We follow [Semantic Ve
 We recommend to have functional tests in the same repository as your application.
 So let's suggest we put them in `selenium-tests/` directory. **In this directory** create a new composer.json file
 (you can use `composer init` command). You will need to have [Composer](http://getcomposer.org/) installed to do this.
-You may also need to set [minimum stability](https://getcomposer.org/doc/04-schema.md#minimum-stability) flag to dev.
 
 Then simply install Steward and add it as a dependency:
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "testing"
     ],
     "license": "MIT",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "Lmc\\Steward\\": "src/"
@@ -26,7 +25,7 @@
         "symfony/event-dispatcher": "~2.6",
         "nette/reflection": "~2.2",
         "nette/utils": "~2.2",
-        "facebook/webdriver": "dev-master",
+        "facebook/webdriver": "~0.6.0",
         "clue/graph": "~0.7.1",
         "florianwolters/component-util-singleton": "0.3.2",
         "caseyamcl/configula": "~2.3",


### PR DESCRIPTION
Version 0.6.0 [was](https://github.com/facebook/php-webdriver/issues/213) just tagged, so we can set dependencies without minimum-stability flags.
