### PR TITLE
Detect other CI servers besides Jenkins

### DIFF
--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -35,4 +35,28 @@ class Command extends \Symfony\Component\Console\Command\Command
     {
         return $this->dispatcher;
     }
+
+    /**
+     * Check if current environment is CI server.
+     *
+     * @codeCoverageIgnore The environment variables behavior is untestable
+     * @return bool|string False if not an CI server, name of the CI server otherwise
+     */
+    protected function isCi()
+    {
+        $ciEnvVariables = [
+            'JENKINS_URL' => 'Jenkins CI',
+            'TRAVIS' => 'Travis CI',
+            'CIRCLECI' => 'CircleCI',
+            'TEAMCITY_VERSION ' => 'TeamCity',
+        ];
+
+        foreach ($ciEnvVariables as $variable => $ciName) {
+            if (getenv($variable)) {
+                return $ciName;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Console/Command/InstallCommand.php
+++ b/src/Console/Command/InstallCommand.php
@@ -118,7 +118,7 @@ class InstallCommand extends Command
                 sprintf(
                     '<info>Steward</info> <comment>%s</comment> is now downloading the Selenium standalone server...%s',
                     $this->getApplication()->getVersion(),
-                    (!getenv('JOB_NAME') ? ' Just for you <fg=red><3</fg=red>!' : '')
+                    (!$this->isCi() ? ' Just for you <fg=red><3</fg=red>!' : '')
                 )
             );
         }

--- a/src/Console/Command/RunTestsCommand.php
+++ b/src/Console/Command/RunTestsCommand.php
@@ -142,7 +142,7 @@ class RunTestsCommand extends Command
             sprintf(
                 '<info>Steward</info> <comment>%s</comment> is running the tests...%s',
                 $this->getApplication()->getVersion(),
-                (!getenv('JOB_NAME') ? ' Just for you <fg=red><3</fg=red>!' : '') // in jenkins it is not just for you
+                (!$this->isCi() ? ' Just for you <fg=red><3</fg=red>!' : '') // on CI server it is not just for you
             )
         );
 


### PR DESCRIPTION
Currently on Jenkins CI is detected by the Jenkins. We should detect also other CI servers. 

Currently only de-facto unimportant eye-candy feature is based on whether it is CI or not, but this could be extended later.
