### PR TITLE
If any test fails, exit with code 0, unless option --no-exit is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - The `logs/results.xml` could now be also accessed locally (the XSLT is now embedded right into the file, so we don't encounter same-origin policy problems).
 - Use tagged version 0.6.0 of [php-webdriver](https://github.com/facebook/php-webdriver).
 - Upgraded to Symfony 2.7 (causing eg. the `--help` format to change a bit - according to [docopt](http://docopt.org/) standard)
+- If any test fails, the `run-tests` command now exits with code `1`. This behavior could be altered using new `--no-exit` option, which forces the command to exit `0` even if some test fails.
 
 ### Fixed
 - Properly trigger PHPUnit colored (ANSI) mode when Steward itself is in ANSI mode.


### PR DESCRIPTION
See #13.

This is important for eg. Travis CI, where build is considered as "passed" if all run commands exits with status zero - so currently even if some of Selenium test fails here, the build is still passing.

However, on other CIs, like Jenkins or Bamboo, non-zero exit code of any command makes the CI believe the whole build failed and it don't process the JUnit results. For these cases, the option `--no-exit` was added (and it should be added to Jenkins builds). Other possibility how to not fail the Jekins build besides adding this option is just to use workaround and run Steward  as `steward.php run-tests ...  || exit 0`, but this may not be as developer friendly.

The reason why i suggest changing the behavior by default is to match the PHPUnit behavior, which returns non-zero exit code if any test fails. 

Thoughts? @tenerd @mplmc @dudla @podlesh
