### PR TITLE
Exclude unnecessary files from being installed through Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.coveralls.yml     export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/ruleset.xml        export-ignore
+/src-tests          export-ignore


### PR DESCRIPTION
Settings those paths as `export-ignore` skipps them from `git archive` so they are not being downloaded, when someone installs Steward using composer (41 instead of 87 files). And if someone wants to developer Steward, he will use git clone anyway.
