### PR TITLE
Don't throw exception for test with named data-sets (fixes #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased.
-- Nothing yet
+### Fixed
+- Tests having @dataProvider and named data-sets were not properly logged with XmlPublisher and exceptions were thrown. ([#28](https://github.com/lmc-eu/steward/issues/28), [#29](https://github.com/lmc-eu/steward/pull/29))
 
 ## 1.1.0 - 2015-06-09
 ### Added
 - Check if browser given to `run-tests` command is supported (this helps avoiding typos, interchange of browser and environment etc.). ([#9](https://github.com/lmc-eu/steward/issues/9), [#15](https://github.com/lmc-eu/steward/pull/15))
-- Option `--filter` which allows filtering tests/testcases by name ([#20](https://github.com/lmc-eu/steward/pull/20)) - @ziizii
+- Option `--filter` which allows filtering tests/testcases by name ([#20](https://github.com/lmc-eu/steward/pull/20)). - @ziizii
 
 ### Changed
 - The `logs/results.xml` could now be also accessed locally (the XSLT is now embedded right into the file, so we don't encounter same-origin policy problems). ([25d73a4](https://github.com/lmc-eu/steward/commit/25d73a4f7e4db348836c4d1f9357d734f9b1c627))

--- a/src/Publisher/XmlPublisher.php
+++ b/src/Publisher/XmlPublisher.php
@@ -157,7 +157,7 @@ class XmlPublisher extends AbstractPublisher
      */
     protected function getTestCaseNode(\SimpleXMLElement $xml, $testCaseName)
     {
-        $testcaseNode = $xml->xpath('//testcase[@name="' . $testCaseName . '"]');
+        $testcaseNode = $xml->xpath(sprintf('//testcase[@name=%s]', $this->quoteXpathAttribute($testCaseName)));
 
         if (!$testcaseNode) {
             $testcaseNode = $xml->addChild('testcase');
@@ -178,7 +178,13 @@ class XmlPublisher extends AbstractPublisher
      */
     protected function getTestNode(\SimpleXMLElement $xml, $testCaseName, $testName)
     {
-        $testNode = $xml->xpath('//testcase[@name="' . $testCaseName . '"]/test[@name="' . $testName . '"]');
+        $testNode = $xml->xpath(
+            sprintf(
+                '//testcase[@name=%s]/test[@name=%s]',
+                $this->quoteXpathAttribute($testCaseName),
+                $this->quoteXpathAttribute($testName)
+            )
+        );
 
         if (!$testNode) {
             $testNode = $xml->addChild('test');
@@ -272,5 +278,22 @@ class XmlPublisher extends AbstractPublisher
         $xsl = file_get_contents($xslPath);
 
         return $xsl;
+    }
+
+    /**
+     * Encapsulate given attribute value into valid xpath expression.
+     * @param string $input Value of an xpath attribute selector
+     * @return string
+     */
+    protected function quoteXpathAttribute($input)
+    {
+        if (strpos($input, '\'') === false) { // Selector does not contain single quotes
+            return "'$input'"; // Encapsulate with double quotes
+        } elseif (strpos($input, '"') === false) { // Selector contain single quotes but not double quotes
+            return "\"$input\""; // Encapsulate with single quotes
+        }
+
+        // When both single and double quotes are contained, escape each part individually and concat() all parts
+        return "concat('" . strtr($input, ['\'' => '\', "\'", \'']) . "')";
     }
 }


### PR DESCRIPTION
Xpath attributes needs to be properly encapsulated with single or double quotes.

Fixes #28.
