### PR TITLE
Print more readable exception when test with duplicate class name is added

### DIFF
--- a/src-tests/Process/ProcessSetTest.php
+++ b/src-tests/Process/ProcessSetTest.php
@@ -39,6 +39,16 @@ class ProcessSetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Testcase with name "Foo\Bar" was already added
+     */
+    public function testShouldFailWhenAddingTestWithNonUniqueName()
+    {
+        $this->set->add(new Process(''), 'Foo\Bar');
+        $this->set->add(new Process(''), 'Foo\Bar');
+    }
+
+    /**
      * @dataProvider delayProvider
      * @param mixed $delay
      * @param string|null $expectedExceptionMessage Null if no exception should be raised

--- a/src/Process/ProcessSet.php
+++ b/src/Process/ProcessSet.php
@@ -97,6 +97,15 @@ class ProcessSet implements \Countable
 
     public function add(Process $process, $className, $delayAfter = '', $delayMinutes = null)
     {
+        if (isset($this->processes[$className])) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Testcase with name "%s" was already added, make sure you don\'t have duplicate class name.',
+                    $className
+                )
+            );
+        }
+
         if (!empty($delayAfter)) {
             if ($delayMinutes === null) {
                 throw new \InvalidArgumentException(


### PR DESCRIPTION
Currently Steward fails like this:

```
  [Fhaculty\Graph\Exception\OverflowException]
  ID must be unique
```

... what is not so readable. New error explaining the problem:

```
  [InvalidArgumentException]
  Testcase with name "Foo\Bar" was already added, make sure you don't have duplicate class name.
```
