### PR TITLE
Date in results.xml shown as invalid in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased.
 ### Fixed
 - Tests having @dataProvider and named data-sets were not properly logged with XmlPublisher and exceptions were thrown. ([#28](https://github.com/lmc-eu/steward/issues/28), [#29](https://github.com/lmc-eu/steward/pull/29))
+- Start and end dates of tests were sometimes not properly displayed when viewing results.xml file in Firefox.
 
 ## 1.1.0 - 2015-06-09
 ### Added

--- a/src/results.xsl
+++ b/src/results.xsl
@@ -217,6 +217,12 @@
             <script>
                 <![CDATA[
                 $(function () {
+                    // Ensure the script was not yet initialized (see Firefox bug #380828)
+                    if (typeof window.wasInitialized != 'undefined') {
+                        return;
+                    }
+                    window.wasInitialized = true;
+
                     // calculate and print test duration
                     $('table tr.test-row').each(function() {
                         var startDate = moment($('td.date-start', this).text());

--- a/src/results.xsl
+++ b/src/results.xsl
@@ -6,7 +6,7 @@
         <html xmlns="http://www.w3.org/1999/xhtml">
             <head>
                 <title>Steward results</title>
-                <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet"/>
+                <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet"/>
             </head>
             <body>
                 <div class="container">
@@ -213,7 +213,7 @@
                     </table>
                 </div>
             <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.3/moment.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
             <script>
                 <![CDATA[
                 $(function () {


### PR DESCRIPTION
Start and end dates of tests were sometimes not properly displayed when viewing results.xml file in Firefox ("Invalid date" was shown instead).

The cause is this Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=380828 - Firefox runs the script twice (once before xsl transformation, once after it), causing the repeated date conversion to break. 

The problem occurs only when converted hour is one-digit value, because date in this format (with just one digit hours) is not re-parseable with Moment.js by default, leading to the "Invalid date" error.
