### PR TITLE
Require PHPUnit 4.8.6 to fix incorrect test status being reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased.
+### Changed
+- Require PHPUnit 4.8.6 to fix incorrect test status being reported (see [phpunit#1835](https://github.com/sebastianbergmann/phpunit/issues/1835)).
+
 ### Fixed
 - Tests having @dataProvider and named data-sets were not properly logged with XmlPublisher and exceptions were thrown. ([#28](https://github.com/lmc-eu/steward/issues/28), [#29](https://github.com/lmc-eu/steward/pull/29))
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.5.5",
         "ext-zip": "*",
         "ext-curl": "*",
-        "phpunit/phpunit": "~4.7",
+        "phpunit/phpunit": "^4.8.6",
         "symfony/console": "~2.7",
         "symfony/process": "~2.7",
         "symfony/finder": "~2.7",


### PR DESCRIPTION
With PHPUnit 4.7.4 skipped tests were reported as errored in the results.xml. This was caused by  https://github.com/sebastianbergmann/phpunit/issues/1835.
