### PR TITLE
Catch consecutive exceptions thrown when webdriver already fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released.
+### Fixed
+- When exception from WebDriver occurs (ie. browser dies or times out), prevent throwing another exception when attempting to closes the session (which leads to PHPUnit not generating any report). ([#7](https://github.com/lmc-eu/steward/issues/7))
 
 ## 1.1.1 - 2015-08-25
 ### Changed

--- a/src/Listener/SnapshotListener.php
+++ b/src/Listener/SnapshotListener.php
@@ -26,7 +26,7 @@ class SnapshotListener extends \PHPUnit_Framework_BaseTestListener
     }
 
     /**
-     * Take screenshot and save it.
+     * Take screenshot and HTML snapshot of the page and save it.
      *
      * @param AbstractTestCase $test
      */
@@ -41,24 +41,29 @@ class SnapshotListener extends \PHPUnit_Framework_BaseTestListener
             . date('Y-m-d-H-i-s');
 
         if (!$test->wd instanceof \RemoteWebDriver) {
-            $test->warn('WebDriver instance not found, cannot take screenshot.');
+            $test->warn('WebDriver instance not found, cannot take snapshot.');
             return;
         }
 
-        $test->appendTestLog(
-            'Test failed on page "%s", taking page snapshots:',
-            $test->wd->getCurrentURL()
-        );
+        try {
+            $test->appendTestLog(
+                'Test failed on page "%s", taking page snapshots:',
+                $test->wd->getCurrentURL()
+            );
 
-        // Save PNG screenshot
-        $screenshotPath = $savePath . $testIdentifier . '.png';
-        $test->wd->takeScreenshot($screenshotPath);
-        $test->appendTestLog('Screenshot saved to file "%s" ', $this->getSnapshotUrl($screenshotPath));
+            // Save PNG screenshot
+            $screenshotPath = $savePath . $testIdentifier . '.png';
+            $test->wd->takeScreenshot($screenshotPath);
+            $test->appendTestLog('Screenshot saved to file "%s" ', $this->getSnapshotUrl($screenshotPath));
 
-        // Save HTML snapshot of page
-        $htmlPath = $savePath . $testIdentifier . '.html';
-        file_put_contents($htmlPath, $test->wd->getPageSource());
-        $test->appendTestLog('HTML snapshot saved to file "%s" ', $this->getSnapshotUrl($htmlPath));
+            // Save HTML snapshot of page
+            $htmlPath = $savePath . $testIdentifier . '.html';
+            file_put_contents($htmlPath, $test->wd->getPageSource());
+            $test->appendTestLog('HTML snapshot saved to file "%s" ', $this->getSnapshotUrl($htmlPath));
+        } catch (\WebDriverException $e) {
+            $test->appendTestLog('Error taking page snapshot, perhaps browser is not accessible?');
+            return;
+        }
     }
 
     /**

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -95,12 +95,18 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
                 $test->wd->getSessionID()
             );
 
-            // Workaround for PhantomJS 1.x - see https://github.com/detro/ghostdriver/issues/343
-            // Should be removed with PhantomJS 2
-            $test->wd->execute('deleteAllCookies');
+            try {
+                // Workaround for PhantomJS 1.x - see https://github.com/detro/ghostdriver/issues/343
+                // Should be removed with PhantomJS 2
+                if (ConfigProvider::getInstance()->browserName == \WebDriverBrowserType::PHANTOMJS) {
+                    $test->wd->execute('deleteAllCookies');
+                }
 
-            $test->wd->close();
-            $test->wd->quit();
+                $test->wd->close();
+                $test->wd->quit();
+            } catch (\WebDriverException $e) {
+                $test->warn('Error closing the session, browser may died.');
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #7, see comments there for reference.
