### PR TITLE
Fix tests failing with latest version of symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": ">=5.5.5",
+        "php": "^5.5.5 || ~7.0",
         "ext-zip": "*",
         "ext-curl": "*",
         "phpunit/phpunit": "^4.8.6",
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.3.4",
-        "php-mock/php-mock-phpunit": "^0.3",
+        "php-mock/php-mock-phpunit": "~1.0",
         "satooshi/php-coveralls": "dev-master"
     },
     "suggest": {

--- a/src-tests/Console/Command/RunTestsCommandTest.php
+++ b/src-tests/Console/Command/RunTestsCommandTest.php
@@ -36,7 +36,7 @@ class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments (missing: "environment, browser").
      */
     public function testShouldFailWithoutArguments()
     {
@@ -47,7 +47,7 @@ class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments (missing: "browser").
      */
     public function testShouldFailWithoutBrowserSpecified()
     {
@@ -58,7 +58,7 @@ class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments.
+     * @expectedExceptionMessage Not enough arguments (missing: "environment").
      */
     public function testShouldFailWithoutEnvironmentSpecified()
     {


### PR DESCRIPTION
Symfony/console added more verbose errors, so we should expect them in our tests.

Also some dependencies were updated.
