### PR TITLE
Sort testcases alphabetically so that the order is same regardless the filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Fixed
 - When exception from WebDriver occurs (ie. browser dies or times out), prevent throwing another exception when attempting to closes the session (which leads to PHPUnit not generating any report). ([#7](https://github.com/lmc-eu/steward/issues/7))
 
+### Changed
+- Sort testcases alphabetically so that the order is same regardless the filesystem
+
 ## 1.1.1 - 2015-08-25
 ### Changed
 - Require PHPUnit 4.8.6 to fix incorrect test status being reported (see [phpunit#1835](https://github.com/sebastianbergmann/phpunit/issues/1835)). ([#34](https://github.com/lmc-eu/steward/pull/34))

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -59,6 +59,9 @@ class ProcessSetCreator
      */
     public function createFromFiles(Finder $files, array $groups = null, array $excludeGroups = null, $filter = null)
     {
+        $files->sortByName();
+        $processSet = $this->getProcessSet();
+
         if ($groups || $excludeGroups || $filter) {
             $this->output->writeln('Filtering testcases:');
         }
@@ -71,8 +74,6 @@ class ProcessSetCreator
         if ($filter) {
             $this->output->writeln(sprintf(' - by testcase/test name: %s', $filter));
         }
-
-        $processSet = $this->getProcessSet();
 
         $testCasesNum = 0;
         foreach ($files as $file) {


### PR DESCRIPTION
In some cases the order returned from filesystem differs on different filesystems. This change makes the order for same testcases same, regardless the filesystem.
