### PR TITLE
Rename "run-tests" command to just "run"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Sort testcases alphabetically so that the order is same regardless the filesystem
+- `run-tests` command renamed to just `run`, keeping the original name as alias to maintain backward compatibility
 
 ## 1.1.1 - 2015-08-25
 ### Changed

--- a/README.md
+++ b/README.md
@@ -122,20 +122,20 @@ receiving the commands and multiple nodes are executing them) - please consult h
 of the Selenium server.
 
 #### Run Steward!
-Having your Selenium server listening, let's launch your test! Use the  `run-tests` command:
+Having your Selenium server listening, let's launch your test! Use the  `run` command:
 
 ```sh
-./vendor/bin/steward run-tests staging firefox
+./vendor/bin/steward run staging firefox
 ```
 
 In few moments you should see Firefox window appearing, then the http://www.w3.org/ site (as defined in the example tests)
 should be loaded and the window will be instantly closed. See output of the command to check the test result.
 
-The `run-tests` command has two required arguments - the name of environment and browser:
+The `run` command has two required arguments - the name of environment and browser:
 - The environment argument has no effect by default, but it is accessible in your tests making it easy to e.g. change the base URL of your tested site - for example your local server or staging environment
 - The browser name could be any name of browser supported by Selenium. Most common are "firefox", "chrome", "phantomjs", "safari" and "internet explorer". Except Firefox some additional steps are needed to run tests in specified browser.
 
-There is also bunch of useful options of `run-tests` command:
+There is also bunch of useful options of `run` command:
 
 - `-vvv` - enable verbose (debug) mode
 - `--group` - run just specific group(s) of tests
@@ -145,7 +145,7 @@ There is also bunch of useful options of `run-tests` command:
 - `--help` - see all other options and default values
 
 ### 5. See the results and screenshots
-The log is printed to the console where you run the `run-tests` command. But this could be a bit confusing, especially if you run multiple tests in parallel.
+The log is printed to the console where you run the `run` command. But this could be a bit confusing, especially if you run multiple tests in parallel.
 
 So for each testcase there is separate file in JUnit XML format, placed in `logs/` directory. Also screenshots and HTML snapsnots are saved into this directory (they are automatically generated on failed assertion or if some WebDriver command fails).
 

--- a/bin/steward
+++ b/bin/steward
@@ -5,7 +5,7 @@ namespace Lmc\Steward;
 
 use Symfony\Component\Console\Application;
 use Lmc\Steward\Console\Command\InstallCommand;
-use Lmc\Steward\Console\Command\RunTestsCommand;
+use Lmc\Steward\Console\Command\RunCommand;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Lmc\Steward\Console\EventListener\ListenerInstantiator;
 
@@ -44,7 +44,7 @@ $application->setDispatcher($dispatcher);
 // Add Commands with injected EventDispatcher to the main console Application
 $application->addCommands(
     [
-        new RunTestsCommand($dispatcher),
+        new RunCommand($dispatcher),
         new InstallCommand($dispatcher),
     ]
 );

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -15,11 +15,11 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 
 /**
- * @covers Lmc\Steward\Console\Command\RunTestsCommand
+ * @covers Lmc\Steward\Console\Command\RunCommand
  */
-class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
+class RunCommandTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var RunTestsCommand */
+    /** @var RunCommand */
     protected $command;
     /** @var CommandTester */
     protected $tester;
@@ -28,9 +28,9 @@ class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
     {
         $dispatcher = new EventDispatcher();
         $application = new Application();
-        $application->add(new RunTestsCommand($dispatcher));
+        $application->add(new RunCommand($dispatcher));
 
-        $this->command = $application->find('run-tests');
+        $this->command = $application->find('run');
         $this->tester = new CommandTester($this->command);
     }
 
@@ -268,8 +268,8 @@ class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(CommandEvents::CONFIGURE), $this->isInstanceOf(BasicConsoleEvent::class));
 
         $application = new Application();
-        $application->add(new RunTestsCommand($dispatcherMock));
-        $command = $application->find('run-tests');
+        $application->add(new RunCommand($dispatcherMock));
+        $command = $application->find('run');
         $command->setSeleniumAdapter($this->getSeleniumAdapterMock());
 
         (new CommandTester($command))->execute(
@@ -288,8 +288,8 @@ class RunTestsCommandTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(CommandEvents::RUN_TESTS_INIT), $this->isInstanceOf(ExtendedConsoleEvent::class));
 
         $application = new Application();
-        $application->add(new RunTestsCommand($dispatcherMock));
-        $command = $application->find('run-tests');
+        $application->add(new RunCommand($dispatcherMock));
+        $command = $application->find('run');
         $command->setSeleniumAdapter($this->getSeleniumAdapterMock());
 
         (new CommandTester($command))->execute(

--- a/src-tests/Console/EventListener/XdebugListenerTest.php
+++ b/src-tests/Console/EventListener/XdebugListenerTest.php
@@ -3,7 +3,7 @@
 namespace Lmc\Steward\Console\EventListener;
 
 use Lmc\Steward\Console\Command\Command;
-use Lmc\Steward\Console\Command\RunTestsCommand;
+use Lmc\Steward\Console\Command\RunCommand;
 use Lmc\Steward\Console\CommandEvents;
 use Lmc\Steward\Console\Event\BasicConsoleEvent;
 use Lmc\Steward\Console\Event\ExtendedConsoleEvent;
@@ -42,7 +42,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldAddXdebugOptionToRunTestsCommand()
     {
-        $command = new RunTestsCommand(new EventDispatcher());
+        $command = new RunCommand(new EventDispatcher());
 
         // Save original options
         $optionsOriginal = $command->getDefinition()->getOptions();
@@ -59,7 +59,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldNotAddXdebugOptionToDifferentCommand()
     {
-        $renamedCommand = new RunTestsCommand(new EventDispatcher());
+        $renamedCommand = new RunCommand(new EventDispatcher());
         $renamedCommand->setName('foo-bar');
 
         // Save original options
@@ -81,7 +81,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
     public function testShouldGetIdeKeyFromCommandOptionOnCommandInitialization($stringInput, $expectedIdeKey)
     {
         $this->mockXdebugExtension($isExtensionLoaded = true, $isRemoteEnabled = true);
-        $command = new RunTestsCommand(new EventDispatcher());
+        $command = new RunCommand(new EventDispatcher());
 
         $input = new StringInput($stringInput);
         $output = new BufferedOutput();
@@ -108,9 +108,9 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
     public function inputProvider()
     {
         return [
-            'use default idekey when no specific value is passed' => ['run-tests --xdebug', 'phpstorm'],
-            'use custom idekey passed as option' => ['run-tests --xdebug=custom', 'custom'],
-            'do nothing if xdebug option not passed' => ['run-tests', null],
+            'use default idekey when no specific value is passed' => ['run --xdebug', 'phpstorm'],
+            'use custom idekey passed as option' => ['run --xdebug=custom', 'custom'],
+            'do nothing if xdebug option not passed' => ['run', null],
         ];
     }
 
@@ -122,7 +122,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockXdebugExtension($isExtensionLoaded = false, $isRemoteEnabled = false);
 
-        $command = new RunTestsCommand(new EventDispatcher());
+        $command = new RunCommand(new EventDispatcher());
         $event = $this->prepareExtendedConsoleEvent(
             $command,
             new StringInput('env firefox --xdebug'),
@@ -140,7 +140,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockXdebugExtension($isExtensionLoaded = true, $isRemoteEnabled = false);
 
-        $command = new RunTestsCommand(new EventDispatcher());
+        $command = new RunCommand(new EventDispatcher());
         $event = $this->prepareExtendedConsoleEvent(
             $command,
             new StringInput('env firefox --xdebug'),
@@ -154,7 +154,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockXdebugExtension($isExtensionLoaded = true, $isRemoteEnabled = true);
 
-        $command = new RunTestsCommand(new EventDispatcher());
+        $command = new RunCommand(new EventDispatcher());
         $input = new StringInput('env firefox --xdebug');
         $output = new BufferedOutput();
 
@@ -178,7 +178,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockXdebugExtension($isExtensionLoaded = true, $isRemoteEnabled = true);
 
-        $command = new RunTestsCommand(new EventDispatcher());
+        $command = new RunCommand(new EventDispatcher());
         $input = new StringInput('env firefox');
         $output = new BufferedOutput();
 

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Lmc\Steward\Process;
 
-use Lmc\Steward\Console\Command\RunTestsCommand;
+use Lmc\Steward\Console\Command\RunCommand;
 use Lmc\Steward\Console\CommandEvents;
 use Lmc\Steward\Console\Event\RunTestsProcessEvent;
 use Lmc\Steward\Publisher\AbstractPublisher;
@@ -22,7 +22,7 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
 {
     /** @var EventDispatcher|\PHPUnit_Framework_MockObject_MockObject */
     protected $dispatcherMock;
-    /** @var RunTestsCommand|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var RunCommand|\PHPUnit_Framework_MockObject_MockObject */
     protected $command;
     /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject */
     protected $input;
@@ -44,7 +44,7 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['dispatch'])
             ->getMock();
 
-        $this->command = new RunTestsCommand($this->dispatcherMock);
+        $this->command = new RunCommand($this->dispatcherMock);
 
         $this->input = new StringInput('staging firefox');
         $this->input->bind($this->command->getDefinition());
@@ -105,10 +105,10 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $expectedEnv = [
             'BROWSER_NAME' => 'firefox',
             'ENV' => 'staging',
-            'SERVER_URL' => $definition->getOption(RunTestsCommand::OPTION_SERVER_URL)->getDefault(),
+            'SERVER_URL' => $definition->getOption(RunCommand::OPTION_SERVER_URL)->getDefault(),
             'PUBLISH_RESULTS' => 0,
-            'FIXTURES_DIR' => $definition->getOption(RunTestsCommand::OPTION_FIXTURES_DIR)->getDefault(),
-            'LOGS_DIR' =>  $definition->getOption(RunTestsCommand::OPTION_LOGS_DIR)->getDefault(),
+            'FIXTURES_DIR' => $definition->getOption(RunCommand::OPTION_FIXTURES_DIR)->getDefault(),
+            'LOGS_DIR' =>  $definition->getOption(RunCommand::OPTION_LOGS_DIR)->getDefault(),
         ];
         $this->assertArraySubset($expectedEnv, $testEnv);
     }
@@ -170,10 +170,10 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->input = new StringInput(
             'trolling chrome'
-            . ' --' . RunTestsCommand::OPTION_SERVER_URL .'=http://foo.bar:1337'
-            . ' --' . RunTestsCommand::OPTION_FIXTURES_DIR .'=custom-fixtures-dir/'
-            . ' --' . RunTestsCommand::OPTION_LOGS_DIR .'=custom-logs-dir/'
-            . ' --' . RunTestsCommand::OPTION_PUBLISH_RESULTS
+            . ' --' . RunCommand::OPTION_SERVER_URL .'=http://foo.bar:1337'
+            . ' --' . RunCommand::OPTION_FIXTURES_DIR .'=custom-fixtures-dir/'
+            . ' --' . RunCommand::OPTION_LOGS_DIR .'=custom-logs-dir/'
+            . ' --' . RunCommand::OPTION_PUBLISH_RESULTS
         );
 
         $this->input->bind($this->command->getDefinition());

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Finder\Finder;
  * Run tests command is used to start Steward test planner and execute tests one by one,
  * optionally with defined delay and relations.
  */
-class RunTestsCommand extends Command
+class RunCommand extends Command
 {
     /** @var SeleniumServerAdapter */
     protected $seleniumAdapter;
@@ -71,7 +71,8 @@ class RunTestsCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('run-tests')
+        $this->setName('run')
+            ->setAliases(['run-tests'])
             ->setDescription('Run tests planner and execute tests')
             ->addArgument(
                 self::ARGUMENT_ENVIRONMENT,

--- a/src/Console/CommandEvents.php
+++ b/src/Console/CommandEvents.php
@@ -18,7 +18,7 @@ final class CommandEvents
     const CONFIGURE = 'command.configure';
 
     /**
-     * The RUN_TESTS_INIT event is dispatched after basic initialization of RunTests Command.
+     * The RUN_TESTS_INIT event is dispatched after basic initialization of Run Command.
      * It allows you to eg. adjust the output on command initialization.
      *
      * The event listener method receives a Lmc\Steward\Console\Event\ExtendedConsoleEvent instance.

--- a/src/Console/Event/RunTestsProcessEvent.php
+++ b/src/Console/Event/RunTestsProcessEvent.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\ProcessBuilder;
 
 /**
- * Event dispatched from run-tests command when initializing PHPUnit Processes.
+ * Event dispatched from `run` command when initializing PHPUnit Processes.
  * It allows you to eg. pass additional arguments to the process.
  */
 class RunTestsProcessEvent extends ExtendedConsoleEvent

--- a/src/Console/EventListener/XdebugListener.php
+++ b/src/Console/EventListener/XdebugListener.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * (see http://xdebug.org/docs/remote for docs)
  *
  * Your IDE must then listen for incoming Xdebug connections on the same port and use the same IDE key.
- * Then start the run-tests command with --xdebug option. For PHPStorm just use the default value ("phpstorm"),
+ * Then start the `run` command with --xdebug option. For PHPStorm just use the default value ("phpstorm"),
  * for eg. NetBeans you must pass "--xdebug=netbeans". See docs of you IDE for more information.
  *
  */
@@ -41,13 +41,13 @@ class XdebugListener implements EventSubscriberInterface
     }
 
     /**
-     * Add option to run-tests command configuration.
+     * Add option to `run` command configuration.
      *
      * @param BasicConsoleEvent $event
      */
     public function onCommandConfigure(BasicConsoleEvent $event)
     {
-        if ($event->getCommand()->getName() != 'run-tests') {
+        if ($event->getCommand()->getName() != 'run') {
             return;
         }
 

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -2,7 +2,7 @@
 
 namespace Lmc\Steward\Process;
 
-use Lmc\Steward\Console\Command\RunTestsCommand;
+use Lmc\Steward\Console\Command\RunCommand;
 use Lmc\Steward\Console\CommandEvents;
 use Lmc\Steward\Console\Event\RunTestsProcessEvent;
 use Lmc\Steward\Publisher\AbstractPublisher;
@@ -19,7 +19,7 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class ProcessSetCreator
 {
-    /** @var RunTestsCommand */
+    /** @var RunCommand */
     protected $command;
     /** @var InputInterface */
     protected $input;
@@ -31,13 +31,13 @@ class ProcessSetCreator
     protected $publisher;
 
     /**
-     * @param RunTestsCommand $command
+     * @param RunCommand $command
      * @param InputInterface $input
      * @param OutputInterface $output
      * @param AbstractPublisher $publisher
      */
     public function __construct(
-        RunTestsCommand $command,
+        RunCommand $command,
         InputInterface $input,
         OutputInterface $output,
         AbstractPublisher $publisher


### PR DESCRIPTION
This is shorter, simpler and much easier to write. 

Backward compatibility is maintained by adding `run-tests` alias for command, thus no BC break is introduced.
