### PR TITLE
Provide information about test results also in CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released.
+### Added
+- Provide information about results of finished processes (verbose (`-v`) mode of `run` command must be enabled)
 
 ## 1.2.0 - 2016-01-11
 ### Added

--- a/src-tests/Component/LegacyTest.php
+++ b/src-tests/Component/LegacyTest.php
@@ -152,7 +152,6 @@ class LegacyTest extends \PHPUnit_Framework_TestCase
         $legacy->setFileDir(sys_get_temp_dir());
 
         $legacy->save('data');
-
     }
 
     public function testShouldAutomaticallySaveAndLoadLegacyIfTestsHavePhaseInItsName()

--- a/src/Publisher/AbstractPublisher.php
+++ b/src/Publisher/AbstractPublisher.php
@@ -3,7 +3,8 @@
 namespace Lmc\Steward\Publisher;
 
 /**
- * Abstract test results publisher.
+ * Abstract test results publisher could be extended and used for reporting test results into some custom system.
+ * Any ancestor class must be registered to TestStatusListener (using phpunit.xml).
  */
 abstract class AbstractPublisher
 {


### PR DESCRIPTION
During test execution it is sometimes handy to know how the tests are going ie. if they pass or not. Currently you can visit the results.xml file that contain visualized information, however, it requires browser etc.

With this improvement, you will see (when at least `-v` verbose mode is enabled) count of each testcases results right in the console - see following example:

![steward-results-2](https://cloud.githubusercontent.com/assets/793041/12354852/f8d0628e-bb98-11e5-8e77-f171145d0dc1.png)
![steward-results-1](https://cloud.githubusercontent.com/assets/793041/12354851/f8cac414-bb98-11e5-8ba1-bb4b0b989b14.png)

Note only result types whose count is greater than zero are part of the output.
