### PR TITLE
Do not install symfony/process >3.0.1 which brokes incremental output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
     - Debug level (`-vvv`) should be used when you want to know all available information about the run or when you run the tests on CI server. The tests output is printed incrementally.
 - Set status of timeouted tests as done and their result as failed
 
+### Fixed
+- Output of tests was missing from the console when using Symfony/Process component 3.0.2.
+
 ## 1.2.0 - 2016-01-11
 ### Added
 - Property annotation added to `SyntaxSugarTrait` to know `$wd` property meaning in IDE. ([#36](https://github.com/lmc-eu/steward/pull/36))

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-curl": "*",
         "phpunit/phpunit": "^4.8.6 || ~5.0",
         "symfony/console": "~3.0",
-        "symfony/process": "~3.0",
+        "symfony/process": "~3.0, <3.0.2",
         "symfony/finder": "~3.0",
         "symfony/event-dispatcher": "~3.0",
         "nette/reflection": "~2.2",


### PR DESCRIPTION
The output produced during test run is not printed. The cause is [bug](https://github.com/symfony/symfony/issues/17937) introduced in Symfony 3.0.2. Until it is fixed, stick on symfony/process 3.0.1.
