### PR TITLE
Delay between tests could be ignored using option --ignore-delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released.
+### Added
+- Option `--ignore-delays` of `run` command to ignore delays defined between tests with `@delayAfter` annotation. Usable when writing or debugging dependent tests. ([#27](https://github.com/lmc-eu/steward/issues/27))
 
 ## 1.3.0 - 2016-02-26
 ### Added

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -174,6 +174,22 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(3.33, $delayedTest->getDelayMinutes());
     }
 
+    public function testShouldIgnoreTestsDelays()
+    {
+        $files = $this->findDummyTests('*Test.php', 'DelayedTests');
+        $processSet = $this->creator->createFromFiles($files, [], [], null, true);
+
+        $processes = $processSet->get(ProcessWrapper::PROCESS_STATUS_QUEUED);
+
+        $firstTest = $processes[FirstTest::class];
+        $delayedTest = $processes[DelayedTest::class];
+        $delayedByZeroTimeTest = $processes[DelayedByZeroTimeTest::class];
+
+        $this->assertFalse($firstTest->isDelayed());
+        $this->assertFalse($delayedByZeroTimeTest->isDelayed());
+        $this->assertFalse($delayedTest->isDelayed());
+    }
+
     public function testShouldThrowExceptionIfAddingTestWithDelayTimeButWithoutDelayedClass()
     {
         $files = $this->findDummyTests('InvalidDelayTest.php', 'InvalidTests');

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -50,6 +50,7 @@ class RunCommand extends Command
     const OPTION_FILTER = 'filter';
     const OPTION_PUBLISH_RESULTS = 'publish-results';
     const OPTION_NO_EXIT = 'no-exit';
+    const OPTION_IGNORE_DELAYS = 'ignore-delays';
 
     /**
      * @param SeleniumServerAdapter $seleniumAdapter
@@ -148,7 +149,14 @@ class RunCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Always exit with code 0 <comment>(by default any failed test causes the command to return 1)</comment>'
+            )
+            ->addOption(
+                self::OPTION_IGNORE_DELAYS,
+                null,
+                InputOption::VALUE_NONE,
+                'Ignore delays defined between testcases'
             );
+        ;
 
         $this->addUsage('staging firefox');
         $this->addUsage('--group=foo --group=bar --exclude-group=baz -vvv development phantomjs');
@@ -222,6 +230,9 @@ class RunCommand extends Command
             $output->writeln(
                 sprintf('Publish results: %s', ($input->getOption(self::OPTION_PUBLISH_RESULTS)) ? 'yes' : 'no')
             );
+            $output->writeln(
+                sprintf('Ignore delays: %s', ($input->getOption(self::OPTION_IGNORE_DELAYS)) ? 'yes' : 'no')
+            );
         }
     }
 
@@ -271,7 +282,8 @@ class RunCommand extends Command
             $files,
             $input->getOption(self::OPTION_GROUP),
             $input->getOption(self::OPTION_EXCLUDE_GROUP),
-            $input->getOption(self::OPTION_FILTER)
+            $input->getOption(self::OPTION_FILTER),
+            $input->getOption(self::OPTION_IGNORE_DELAYS)
         );
 
         if (!count($processSet)) {

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -55,10 +55,16 @@ class ProcessSetCreator
      * @param array $groups Groups to be run
      * @param array $excludeGroups Groups to be excluded
      * @param string $filter filter test cases by name
+     * @param bool $ignoreDelays Should test delays be ignored?
      * @return ProcessSet
      */
-    public function createFromFiles(Finder $files, array $groups = null, array $excludeGroups = null, $filter = null)
-    {
+    public function createFromFiles(
+        Finder $files,
+        array $groups = null,
+        array $excludeGroups = null,
+        $filter = null,
+        $ignoreDelays = false
+    ) {
         $files->sortByName();
         $processSet = $this->getProcessSet();
 
@@ -140,19 +146,21 @@ class ProcessSetCreator
             $className = key($classes);
             $processWrapper = new ProcessWrapper($this->buildProcess($fileName, $phpunitArgs), $className);
 
-            $delayAfter = !empty($annotations['delayAfter']) ? current($annotations['delayAfter']) : '';
-            $delayMinutes = !empty($annotations['delayMinutes']) ? current($annotations['delayMinutes']) : null;
-            if ($delayAfter) {
-                $processWrapper->setDelay($delayAfter, $delayMinutes);
-            } elseif ($delayMinutes !== null && empty($delayAfter)) {
-                throw new \InvalidArgumentException(
-                    sprintf(
-                        'Testcase "%s" has defined delay %d minutes, '
-                        . 'but doesn\'t have defined the testcase to run after',
-                        $className,
-                        $delayMinutes
-                    )
-                );
+            if (!$ignoreDelays) {
+                $delayAfter = !empty($annotations['delayAfter']) ? current($annotations['delayAfter']) : '';
+                $delayMinutes = !empty($annotations['delayMinutes']) ? current($annotations['delayMinutes']) : null;
+                if ($delayAfter) {
+                    $processWrapper->setDelay($delayAfter, $delayMinutes);
+                } elseif ($delayMinutes !== null && empty($delayAfter)) {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            'Testcase "%s" has defined delay %d minutes, '
+                            . 'but doesn\'t have defined the testcase to run after',
+                            $className,
+                            $delayMinutes
+                        )
+                    );
+                }
             }
 
             $processSet->add($processWrapper);


### PR DESCRIPTION
Fixes #27.

This is useful when writing or debugging dependent test, and you want to run just the test which has dependency on some other test (and you eg. don't require the dependency while implementing the test).
