### PR TITLE
Improve error message when class cannot be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Throw explanatory exception when attempting to load test file without any test class defined (instead of confusing `ReflectionException`).
+- Throw explanatory exception when test class cannot be instantiated (if class name/namespace doesn't match file path).
 
 ## 1.3.0 - 2016-02-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Unreleased
 - Nothing yet - everything is released.
 
+### Changed
+- Throw explanatory exception when attempting to load test file without any test class defined (instead of confusing `ReflectionException`).
+
 ## 1.3.0 - 2016-02-26
 ### Added
 - Provide information about results of finished processes in output of the `run` command. ([#44](https://github.com/lmc-eu/steward/pull/44))

--- a/src-tests/Process/Fixtures/InvalidTests/NoClassTest.php
+++ b/src-tests/Process/Fixtures/InvalidTests/NoClassTest.php
@@ -1,0 +1,3 @@
+<?php
+
+// no class there

--- a/src-tests/Process/Fixtures/InvalidTests/WrongClassTest.php
+++ b/src-tests/Process/Fixtures/InvalidTests/WrongClassTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lmc\Steward\Process\Fixtures\InvalidTests;
+
+use Lmc\Steward\Test\AbstractTestCase;
+
+/**
+ * Class with wrong name (differs from name of the file)
+ */
+class ReallyWrongClassTest extends AbstractTestCase
+{
+}

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -126,6 +126,19 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $this->creator->createFromFiles($files, [], []);
     }
 
+    public function testShouldThrowExceptionIfAddingClassWithNameMismatchingTheFileName()
+    {
+        $files = $this->findDummyTests('WrongClassTest.php', 'InvalidTests');
+
+        $fileName = key(iterator_to_array($files->getIterator()));
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'Error loading class "Lmc\Steward\Process\Fixtures\InvalidTests\ReallyWrongClassTest" from file "'
+            . $fileName . '". Make sure the class name and namespace matches the file path.'
+        );
+        $this->creator->createFromFiles($files, [], []);
+    }
+
     public function testShouldOnlyAddTestsOfGivenGroups()
     {
         $processSet = $this->creator->createFromFiles($this->findDummyTests(), ['bar', 'foo'], []);

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -114,6 +114,18 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $this->assertArraySubset($expectedEnv, $testEnv);
     }
 
+    public function testShouldThrowExceptionIfAddingFileWithNoClass()
+    {
+        $files = $this->findDummyTests('NoClassTest.php', 'InvalidTests');
+
+        $fileName = key(iterator_to_array($files->getIterator()));
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'No class found in file "' . $fileName . '"'
+        );
+        $this->creator->createFromFiles($files, [], []);
+    }
+
     public function testShouldOnlyAddTestsOfGivenGroups()
     {
         $processSet = $this->creator->createFromFiles($this->findDummyTests(), ['bar', 'foo'], []);

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -88,7 +88,18 @@ class ProcessSetCreator
             }
 
             // Get annotations for the first class in testcase (one file = one class)
-            $annotations = AnnotationsParser::getAll(new \ReflectionClass(key($classes)));
+            try {
+                $annotations = AnnotationsParser::getAll(new \ReflectionClass(key($classes)));
+            } catch (\ReflectionException $e) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Error loading class "%s" from file "%s". Make sure the class name and namespace matches '
+                        . 'the file path.',
+                        key($classes),
+                        $fileName
+                    )
+                );
+            }
 
             // Filter out test-cases having any of excluded groups
             if ($excludeGroups && array_key_exists('group', $annotations)

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -83,6 +83,10 @@ class ProcessSetCreator
             // Parse classes from the testcase file
             $classes = AnnotationsParser::parsePhp(\file_get_contents($fileName));
 
+            if (empty($classes)) {
+                throw new \RuntimeException(sprintf('No class found in file "%s"', $fileName));
+            }
+
             // Get annotations for the first class in testcase (one file = one class)
             $annotations = AnnotationsParser::getAll(new \ReflectionClass(key($classes)));
 


### PR DESCRIPTION
Provide more explanatory exception messages when file contains no class or when class name mismatches the file name and thus cannot be loaded (PSR-4 autoloading violation).

This also partially improves the problem #51 (at least the exception makes sense a bit).
