### PR TITLE
Skip queued dependants of failed testcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Throw explanatory exception when attempting to load test file without any test class defined (instead of confusing `ReflectionException`).
 - Throw explanatory exception when test class cannot be instantiated (if class name/namespace doesn't match file path).
+- Testcases depending on failed testcase are instantly marked as failed and skipped. ([#47](https://github.com/lmc-eu/steward/issues/47))
 
 ## 1.3.0 - 2016-02-26
 ### Added

--- a/src-tests/Process/ProcessWrapperTest.php
+++ b/src-tests/Process/ProcessWrapperTest.php
@@ -132,6 +132,7 @@ class ProcessWrapperTest extends \PHPUnit_Framework_TestCase
             'Process was killed' => [9, ProcessWrapper::PROCESS_RESULT_FATAL],
             'Process was terminated' => [9, ProcessWrapper::PROCESS_RESULT_FATAL],
             'Unrecognized exit error code should mark result as failed' => [66, ProcessWrapper::PROCESS_RESULT_FAILED],
+            'None exit code (null) should mark result as failed' => [null, ProcessWrapper::PROCESS_RESULT_FAILED],
         ];
     }
 

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -419,6 +419,22 @@ class RunCommand extends Command
                             sprintf('<fg=red>Testcase "%s" %s</>', $testClass, $processWrapper->getResult())
                         );
                     }
+
+                    // Fail also process dependencies
+                    if (!$hasProcessPassed) {
+                        $failedDependants = $processSet->failDependants($testClass);
+                        if ($output->isVerbose()) {
+                            foreach ($failedDependants as $failedClass => $failedProcessWrapper) {
+                                $output->writeln(
+                                    sprintf(
+                                        '<fg=red>Failing testcase "%s", because it was depending on failed "%s"</>',
+                                        $failedClass,
+                                        $testClass
+                                    )
+                                );
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/Process/ProcessWrapper.php
+++ b/src/Process/ProcessWrapper.php
@@ -213,7 +213,14 @@ class ProcessWrapper
      */
     private function resolveResult()
     {
-        switch ($this->getProcess()->getExitCode()) {
+        $exitCode = $this->getProcess()->getExitCode();
+
+        // If the process was not even started, mark its result as failed
+        if ($exitCode === null) {
+            return self::PROCESS_RESULT_FAILED;
+        }
+
+        switch ($exitCode) {
             case \PHPUnit_TextUI_TestRunner::SUCCESS_EXIT: // all tests passed
                 $result = self::PROCESS_RESULT_PASSED;
                 // for passed process save just the status and result; end time was saved by TestStatusListener


### PR DESCRIPTION
Ref. #47.

If testcase fails, all of its dependencies are also immediately marked as failed and skipped (removed from the queue).
