### PR TITLE
Allow symfony/process 3.0.4+ to be installed (see #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Throw explanatory exception when attempting to load test file without any test class defined (instead of confusing `ReflectionException`).
 - Throw explanatory exception when test class cannot be instantiated (if class name/namespace doesn't match file path).
 - Testcases depending on failed testcase are instantly marked as failed and skipped. ([#47](https://github.com/lmc-eu/steward/issues/47))
+- Allow Symfony/Process 3.0.4+ to be installed.
 
 ## 1.3.0 - 2016-02-26
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-curl": "*",
         "phpunit/phpunit": "^4.8.6 || ~5.0",
         "symfony/console": "~3.0",
-        "symfony/process": "~3.0, <3.0.2",
+        "symfony/process": "^3.0.4",
         "symfony/finder": "~3.0",
         "symfony/event-dispatcher": "~3.0",
         "nette/reflection": "~2.2",
@@ -36,7 +36,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.3.4 || ^2.4.1",
         "php-mock/php-mock-phpunit": "~1.0",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "^1.0"
     },
     "suggest": {
         "ext-posix": "For colored output",


### PR DESCRIPTION
See #48 and https://github.com/symfony/symfony/issues/17937, which was fixed in Symfony 3.0.4.
