### PR TITLE
Fix process status and result publishing to xml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released.
+### Fixed
+- Process status and result was not properly published to results.xml file.
 
 ## 1.4.0 - 2016-04-07
 ### Added

--- a/src-tests/Process/ProcessWrapperTest.php
+++ b/src-tests/Process/ProcessWrapperTest.php
@@ -156,13 +156,13 @@ class ProcessWrapperTest extends \PHPUnit_Framework_TestCase
         $wrapper->setStatus('WrongStatus');
     }
 
-    public function testShouldPublishProcessStatusWhenStatusWasSet()
+    public function testShouldPublishProcessStatusWhenInitializedAndWhenStatusWasSet()
     {
         $publisherMock = $this->getMockBuilder(XmlPublisher::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $publisherMock->expects($this->once())
+        $publisherMock->expects($this->at(0))
             ->method('publishResults')
             ->with(
                 'FooClassName',
@@ -172,10 +172,19 @@ class ProcessWrapperTest extends \PHPUnit_Framework_TestCase
                 $this->identicalTo(null)
             );
 
-        $wrapper = new ProcessWrapper(new Process(''), 'FooClassName');
-        $wrapper->setPublisher($publisherMock);
+        $publisherMock->expects($this->at(1))
+            ->method('publishResults')
+            ->with(
+                'FooClassName',
+                ProcessWrapper::PROCESS_STATUS_DONE,
+                $this->identicalTo(ProcessWrapper::PROCESS_RESULT_FAILED),
+                $this->identicalTo(null),
+                $this->identicalTo(null)
+            );
 
-        $wrapper->setStatus(ProcessWrapper::PROCESS_STATUS_QUEUED);
+        $wrapper = new ProcessWrapper(new Process(''), 'FooClassName', $publisherMock);
+
+        $wrapper->setStatus(ProcessWrapper::PROCESS_STATUS_DONE);
     }
 
     public function testShouldReturnErrorMessageIfProcessTimeoutIsDetected()

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -159,7 +159,11 @@ class ProcessSetCreator
             }
 
             $className = key($classes);
-            $processWrapper = new ProcessWrapper($this->buildProcess($fileName, $phpunitArgs), $className);
+            $processWrapper = new ProcessWrapper(
+                $this->buildProcess($fileName, $phpunitArgs),
+                $className,
+                $this->publisher
+            );
 
             if (!$ignoreDelays) {
                 $delayAfter = !empty($annotations['delayAfter']) ? current($annotations['delayAfter']) : '';

--- a/src/Process/ProcessWrapper.php
+++ b/src/Process/ProcessWrapper.php
@@ -59,20 +59,14 @@ class ProcessWrapper
     /**
      * @param Process $process Instance of PHPUnit process
      * @param string $className Tested class fully qualified name
+     * @param AbstractPublisher $publisher
      */
-    public function __construct(Process $process, $className)
+    public function __construct(Process $process, $className, AbstractPublisher $publisher = null)
     {
         $this->process = $process;
         $this->className = $className;
-        $this->setStatus(self::PROCESS_STATUS_QUEUED);
-    }
-
-    /**
-     * @param AbstractPublisher $publisher
-     */
-    public function setPublisher(AbstractPublisher $publisher)
-    {
         $this->publisher = $publisher;
+        $this->setStatus(self::PROCESS_STATUS_QUEUED);
     }
 
     /**
@@ -158,14 +152,13 @@ class ProcessWrapper
 
         $this->status = $status;
 
-        $result = null;
         if ($status == self::PROCESS_STATUS_DONE) {
             $this->result = $this->resolveResult();
             $this->finishedTime = time();
         }
 
         if ($this->publisher) {
-            $this->publisher->publishResults($this->getClassName(), $status, $result);
+            $this->publisher->publishResults($this->getClassName(), $status, $this->result);
         }
     }
 


### PR DESCRIPTION
Publisher instance was not passed to the ProcessWrapper, so that the status wasn't be saved.

Moreover, wrong variable was used when saving the result after result of done process was resolved, making it never being saved to the xml file - even with the publisher instance.

Thanks @minarikv for pointing out!
