### PR TITLE
Show deprecation warning for run-tests command alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released.
+### Changed
+- Prepare removal of deprecated features - show deprecation warning when `run-tests` alias is being used. Note this alias and also non-namespaced WebDriver (deprecated in 1.2.0) will be removed in future Steward versions!
 
 ## 1.4.1 - 2016-04-28
 ### Fixed

--- a/src/Console/EventListener/DeprecatedWarningListener.php
+++ b/src/Console/EventListener/DeprecatedWarningListener.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Lmc\Steward\Console\EventListener;
+
+use Lmc\Steward\Component\Environment;
+use Lmc\Steward\Console\CommandEvents;
+use Lmc\Steward\Console\Event\BasicConsoleEvent;
+use Lmc\Steward\Console\Event\ExtendedConsoleEvent;
+use Lmc\Steward\Console\Event\RunTestsProcessEvent;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Show deprecation warning when run-tests alias is used
+ *
+ * @codeCoverageIgnore
+ */
+class DeprecatedWarningListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            CommandEvents::RUN_TESTS_INIT => 'onCommandRunTestsInit',
+        ];
+    }
+
+    /**
+     * @param ExtendedConsoleEvent $event
+     */
+    public function onCommandRunTestsInit(ExtendedConsoleEvent $event)
+    {
+        $output = $event->getOutput();
+        $input = $event->getInput();
+
+        if ($input->getArgument('command') == 'run-tests') {
+            $output->writeln(
+                '<error>You are using depracated "run-tests" command name, which will be removed in '
+                . 'future Steward versions. Use "run" command instead!</>'
+            );
+        }
+    }
+}


### PR DESCRIPTION
Run-tests command was deprecated in Steward 1.2.0 and will be entirely removed in future major Steward version.
