### PR TITLE
Command to clean logs directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).
 - Command `clean` to remove old content of logs directory (previous png screenshots, HTML snapshots and JUnit xmls).
 
+### Changed
+- Content of directory with logs is cleaned before `run` command starts by default. This could be suppressed using `--no-clean` option of the `run` command. ([#63](https://github.com/lmc-eu/steward/issues/63))
+- Directory for logs is automatically created if it does not exist. ([#67](https://github.com/lmc-eu/steward/issues/67))
+
 ## 1.5.0 - 2016-05-05
 ### Added
 - Shortcut `-i` to invoke `--ignore-delays` option of `run` command. ([#69](https://github.com/lmc-eu/steward/pull/69))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).
+- Command `clean` to remove old content of logs directory (previous png screenshots, HTML snapshots and JUnit xmls).
 
 ## 1.5.0 - 2016-05-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Then simply install Steward and add it as a dependency:
 $ composer require lmc/steward
 ```
 
-Next necessary step is to create `tests/` and `logs/` directory inside the `selenium-tests/` directory.
-
 ### 2. Install Selenium
 You need Selenium server installed to execute commands in the specified browser.
 In the root directory of your tests (e.g. `selenium-tests/`)  simply run:
@@ -71,7 +69,7 @@ Steward. For the following example it is as easy as adding following to your `co
         }
     }
 ```
-Don't forget to run `composer dump-autoload` afterwards.
+Don't forget to create the `selenium-tests/tests/` directory and to run `composer dump-autoload` afterwards.
 
 Now the test itself (place it to `selenium-tests/tests/` directory):
 

--- a/bin/steward
+++ b/bin/steward
@@ -3,6 +3,7 @@
 
 namespace Lmc\Steward;
 
+use Lmc\Steward\Console\Command\CleanCommand;
 use Lmc\Steward\Console\Command\InstallCommand;
 use Lmc\Steward\Console\Command\ResultsCommand;
 use Lmc\Steward\Console\Command\RunCommand;
@@ -47,6 +48,7 @@ $application->setDispatcher($dispatcher);
 // Add Commands with injected EventDispatcher to the main console Application
 $application->addCommands(
     [
+        new CleanCommand($dispatcher),
         new RunCommand($dispatcher),
         new ResultsCommand($dispatcher),
         new InstallCommand($dispatcher),

--- a/src-tests/Console/Command/CleanCommandTest.php
+++ b/src-tests/Console/Command/CleanCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Lmc\Steward\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @covers Lmc\Steward\Console\Command\CleanCommand
+ */
+class CleanCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var CleanCommand */
+    protected $command;
+    /** @var CommandTester */
+    protected $tester;
+
+    protected function setUp()
+    {
+        $dispatcher = new EventDispatcher();
+        $application = new Application();
+        $application->add(new CleanCommand($dispatcher));
+
+        $this->command = $application->find('clean');
+        $this->tester = new CommandTester($this->command);
+    }
+
+    public function testShouldShowErrorIfLogsDirectoryCannotBeFound()
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'Cannot clean logs directory "/not/accessible", make sure it is accessible.'
+        );
+
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
+                '--logs-dir' => '/not/accessible',
+            ]
+        );
+    }
+
+    public function testShouldCleanLogsDirectory()
+    {
+        $dir = __DIR__ . '/Fixtures/logs/';
+        $fs = new Filesystem();
+        $fs->touch([$dir . 'foo.png', $dir . 'bar.html', $dir . 'baz.xml', $dir . 'results.xml']);
+
+        $filesCountBefore = (new Finder())->files()->in($dir)->count();
+
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
+                '--logs-dir' => $dir,
+            ]
+        );
+
+        $filesCountAfter = (new Finder())->files()->in($dir)->count();
+        $output = $this->tester->getDisplay();
+
+        $this->assertSame(0, $this->tester->getStatusCode());
+        $this->assertSame($filesCountAfter, $filesCountBefore - 3);
+        $this->assertFileNotExists($dir . 'foo.png');
+        $this->assertFileNotExists($dir . 'foo.bar');
+        $this->assertFileNotExists($dir . 'foo.html');
+        $this->assertFileExists($dir . 'results.xml');
+        $this->assertEmpty($output);
+    }
+}

--- a/src-tests/Console/Command/CleanCommandTest.php
+++ b/src-tests/Console/Command/CleanCommandTest.php
@@ -29,17 +29,42 @@ class CleanCommandTest extends \PHPUnit_Framework_TestCase
         $this->tester = new CommandTester($this->command);
     }
 
-    public function testShouldShowErrorIfLogsDirectoryCannotBeFound()
+    public function testShouldShowErrorIfLogsDirectoryIsNotDefaultAndCannotBeFound()
     {
         $this->setExpectedException(
             \RuntimeException::class,
-            'Cannot clean logs directory "/not/accessible", make sure it is accessible.'
+            'Cannot clean logs directory "/custom/not/accessible/path", make sure it is accessible.'
         );
 
         $this->tester->execute(
             [
                 'command' => $this->command->getName(),
-                '--logs-dir' => '/not/accessible',
+                '--logs-dir' => '/custom/not/accessible/path',
+            ]
+        );
+    }
+
+    public function testShouldCreateLogsDirectoryIfDefaultPathIsUsed()
+    {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Filesystem $filesystemMock */
+        $filesystemMock = $this->getMockBuilder(Filesystem::class)
+            ->setMethods(['exists', 'mkdir'])
+            ->getMock();
+
+        // Make default logs directory appear as not existing
+        $filesystemMock->expects($this->once())
+            ->method('exists')
+            ->willReturn(false);
+
+        // The directory should be created then
+        $filesystemMock->expects($this->once())
+            ->method('mkdir');
+
+        $this->command->setFilesystem($filesystemMock);
+
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
             ]
         );
     }

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -100,9 +100,9 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function directoryOptionsProvider()
     {
         return [
-            ['tests-dir', 'Path to directory with tests does not exist'],
-            ['logs-dir', 'Path to directory with logs does not exist'],
-            ['fixtures-dir', 'Base path to directory with fixture files does not exist'],
+            ['tests-dir', 'Path to directory with tests "/not/accessible" does not exist'],
+            ['logs-dir', 'Path to directory with logs "/not/accessible" does not exist'],
+            ['fixtures-dir', 'Base path to directory with fixture files "/not/accessible" does not exist'],
         ];
     }
 

--- a/src-tests/Console/EventListener/CleanLogsListenerTest.php
+++ b/src-tests/Console/EventListener/CleanLogsListenerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Lmc\Steward\Console\EventListener;
+
+use Lmc\Steward\Console\Command\CleanCommand;
+use Lmc\Steward\Console\Command\Command;
+use Lmc\Steward\Console\Command\RunCommand;
+use Lmc\Steward\Console\CommandEvents;
+use Lmc\Steward\Console\Event\BasicConsoleEvent;
+use Lmc\Steward\Console\Event\ExtendedConsoleEvent;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @covers Lmc\Steward\Console\EventListener\CleanLogsListener
+ */
+class CleanLogsListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var CleanLogsListener */
+    protected $listener;
+
+    protected function setUp()
+    {
+        $this->listener = new CleanLogsListener();
+    }
+
+    public function testShouldSubscribeToEvents()
+    {
+        $subscribedEvents = $this->listener->getSubscribedEvents();
+
+        $this->assertArrayHasKey(CommandEvents::CONFIGURE, $subscribedEvents);
+        $this->assertArrayHasKey(CommandEvents::RUN_TESTS_INIT, $subscribedEvents);
+    }
+
+    public function testShouldAddNoCleanOptionToRunTestsCommand()
+    {
+        $command = new RunCommand(new EventDispatcher());
+
+        // Save original options
+        $optionsOriginal = $command->getDefinition()->getOptions();
+
+        // Trigger the event
+        $this->listener->onCommandConfigure(new BasicConsoleEvent($command));
+
+        // The original options should now be appended with no-clean option
+        $optionsWithNoClean = $command->getDefinition()->getOptions();
+
+        $this->assertCount(count($optionsOriginal) + 1, $optionsWithNoClean);
+        $this->assertArrayHasKey(CleanLogsListener::OPTION_NO_CLEAN, $optionsWithNoClean);
+    }
+
+    public function testShouldNotAddNoCleanOptionToDifferentCommand()
+    {
+        $renamedCommand = new RunCommand(new EventDispatcher());
+        $renamedCommand->setName('foo-bar');
+
+        // Save original options
+        $optionsOriginal = $renamedCommand->getDefinition()->getOptions();
+
+        // Trigger the event
+        $this->listener->onCommandConfigure(new BasicConsoleEvent($renamedCommand));
+
+        // The new options should be still the same, not altered
+        $optionsNew = $renamedCommand->getDefinition()->getOptions();
+        $this->assertSame($optionsOriginal, $optionsNew);
+    }
+
+    public function testShouldInvokeCleanCommand()
+    {
+        $command = new RunCommand(new EventDispatcher());
+        $eventMock = $this->prepareExtendedConsoleEventMock(
+            $command,
+            new StringInput(''),
+            new BufferedOutput()
+        );
+
+        $cleanCommandMock = $this->getMockBuilder(CleanCommand::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $cleanCommandMock->expects($this->once())
+            ->method('run');
+
+        $applicationMock = $this->getMockBuilder(Application::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $applicationMock->expects($this->once())
+            ->method('find')
+            ->with('clean')
+            ->willReturn($cleanCommandMock);
+
+        $runCommandMock = $this->getMockBuilder(RunCommand::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $runCommandMock->expects($this->once())
+            ->method('getApplication')
+            ->willReturn($applicationMock);
+
+        $eventMock->expects($this->once())
+            ->method('getCommand')
+            ->willReturn($runCommandMock);
+
+        $this->listener->onCommandRunTestsInit($eventMock);
+    }
+
+    public function testShouldNotInvokeCleanIfNoCleanOptionGiven()
+    {
+        $command = new RunCommand(new EventDispatcher());
+        $eventMock = $this->prepareExtendedConsoleEventMock(
+            $command,
+            new StringInput('--no-clean'),
+            new BufferedOutput()
+        );
+
+        $eventMock->expects($this->never())
+            ->method('getCommand');
+
+        $this->listener->onCommandRunTestsInit($eventMock);
+    }
+
+    /**
+     * Prepare ExtendedConsoleEvent that could be passed to onCommandRunTestsInit().
+     *
+     * @param Command $command
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return \PHPUnit_Framework_MockObject_MockObject|ExtendedConsoleEvent
+     */
+    protected function prepareExtendedConsoleEventMock($command, $input, $output)
+    {
+        // Trigger event to add the option to the command and bind the definition to the input
+        $this->listener->onCommandConfigure(new BasicConsoleEvent($command));
+        $input->bind($command->getDefinition());
+
+        $event = $this->getMockBuilder(ExtendedConsoleEvent::class)
+            ->setConstructorArgs([$command, $input, $output])
+            ->setMethods(['getCommand'])
+            ->getMock();
+
+        return $event;
+    }
+}

--- a/src-tests/Console/EventListener/XdebugListenerTest.php
+++ b/src-tests/Console/EventListener/XdebugListenerTest.php
@@ -54,7 +54,7 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
         $optionsWithXdebug = $command->getDefinition()->getOptions();
 
         $this->assertCount(count($optionsOriginal) + 1, $optionsWithXdebug);
-        $this->assertArrayHasKey('xdebug', $optionsWithXdebug);
+        $this->assertArrayHasKey(XdebugListener::OPTION_XDEBUG, $optionsWithXdebug);
     }
 
     public function testShouldNotAddXdebugOptionToDifferentCommand()

--- a/src/Console/Command/CleanCommand.php
+++ b/src/Console/Command/CleanCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Lmc\Steward\Console\Command;
+
+use Lmc\Steward\Console\CommandEvents;
+use Lmc\Steward\Console\Event\BasicConsoleEvent;
+use Lmc\Steward\Publisher\XmlPublisher;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Clean previous log files in the logs directory
+ */
+class CleanCommand extends Command
+{
+    /**
+     * Configure command
+     */
+    protected function configure()
+    {
+        $this->setName('clean')
+            ->setDescription('Clean logs directory')
+            ->addOption(
+                RunCommand::OPTION_LOGS_DIR,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to directory with logs',
+                STEWARD_BASE_DIR . '/logs'
+            );
+
+        $this->getDispatcher()->dispatch(CommandEvents::CONFIGURE, new BasicConsoleEvent($this));
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $logsDir = $input->getOption(RunCommand::OPTION_LOGS_DIR);
+
+        if (!realpath($logsDir)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Cannot clean logs directory "%s", make sure it is accessible.',
+                    $logsDir
+                )
+            );
+        }
+
+        $this->cleanDirectory($logsDir);
+
+        return 0;
+    }
+
+    private function cleanDirectory($logsDir)
+    {
+        $finder = (new Finder())
+            ->files()
+            ->in($logsDir)
+            ->depth('== 0')
+            ->name('*.html')
+            ->name('*.png')
+            ->name('*.xml')
+            ->notName(XmlPublisher::FILE_NAME);
+
+        $fs = new Filesystem();
+
+        /** @var SplFileInfo $file */
+        foreach ($finder as $file) {
+            $fs->remove($file->getRealPath());
+        }
+    }
+}

--- a/src/Console/Command/CleanCommand.php
+++ b/src/Console/Command/CleanCommand.php
@@ -21,6 +21,7 @@ class CleanCommand extends Command
     private $filesystem;
 
     /**
+     * @internal
      * @param Filesystem $filesystem
      */
     public function setFilesystem(Filesystem $filesystem)

--- a/src/Console/Command/InstallCommand.php
+++ b/src/Console/Command/InstallCommand.php
@@ -26,24 +26,12 @@ class InstallCommand extends Command
     protected $targetDir = '/vendor/bin';
 
     /**
+     * @internal
      * @param Downloader $downloader
      */
     public function setDownloader(Downloader $downloader)
     {
         $this->downloader = $downloader;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     * @return Downloader
-     */
-    public function getDownloader()
-    {
-        if (!$this->downloader) {
-            $this->downloader = new Downloader(STEWARD_BASE_DIR . $this->targetDir);
-        }
-
-        return $this->downloader;
     }
 
     /**
@@ -167,5 +155,18 @@ class InstallCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return Downloader
+     */
+    protected function getDownloader()
+    {
+        if (!$this->downloader) {
+            $this->downloader = new Downloader(STEWARD_BASE_DIR . $this->targetDir);
+        }
+
+        return $this->downloader;
     }
 }

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -98,21 +98,21 @@ class RunCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Path to directory with tests',
-                realpath(STEWARD_BASE_DIR . '/tests')
+                STEWARD_BASE_DIR . '/tests'
             )
             ->addOption(
                 self::OPTION_FIXTURES_DIR,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Base path to directory with fixture files',
-                realpath(STEWARD_BASE_DIR . '/tests')
+                STEWARD_BASE_DIR . '/tests'
             )
             ->addOption(
                 self::OPTION_LOGS_DIR,
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Path to directory with logs',
-                realpath(STEWARD_BASE_DIR . '/logs')
+                STEWARD_BASE_DIR . '/logs'
             )
             ->addOption(
                 self::OPTION_PATTERN,
@@ -210,6 +210,11 @@ class RunCommand extends Command
             $output->writeln(sprintf('Environment: %s', $input->getArgument(self::ARGUMENT_ENVIRONMENT)));
         }
 
+        $this->getDispatcher()->dispatch(
+            CommandEvents::RUN_TESTS_INIT,
+            new ExtendedConsoleEvent($this, $input, $output)
+        );
+
         // Check if directories exists
         $this->testDirectories(
             $input,
@@ -246,11 +251,6 @@ class RunCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->getDispatcher()->dispatch(
-            CommandEvents::RUN_TESTS_INIT,
-            new ExtendedConsoleEvent($this, $input, $output)
-        );
-
         if (!$this->testSeleniumConnection($output, $input->getOption(self::OPTION_SERVER_URL))) {
             return 1;
         }
@@ -565,11 +565,12 @@ class RunCommand extends Command
         foreach ($dirs as $dir) {
             $currentValue = $input->getOption($dir->getName());
 
-            if ($currentValue === false || realpath($currentValue) === false) {
+            if (realpath($currentValue) === false || !is_readable($currentValue)) {
                 throw new \RuntimeException(
                     sprintf(
-                        '%s does not exist, make sure it is accessible or define your own path using %s option',
+                        '%s "%s" does not exist, make sure it is accessible or define your own path using %s option',
                         $dir->getDescription(),
+                        $currentValue,
                         '--' . $dir->getName()
                     )
                 );

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -53,6 +53,7 @@ class RunCommand extends Command
     const OPTION_IGNORE_DELAYS = 'ignore-delays';
 
     /**
+     * @internal
      * @param SeleniumServerAdapter $seleniumAdapter
      */
     public function setSeleniumAdapter(SeleniumServerAdapter $seleniumAdapter)
@@ -61,6 +62,7 @@ class RunCommand extends Command
     }
 
     /**
+     * @internal
      * @param ProcessSetCreator $processSetCreator
      */
     public function setProcessSetCreator(ProcessSetCreator $processSetCreator)

--- a/src/Console/EventListener/CleanLogsListener.php
+++ b/src/Console/EventListener/CleanLogsListener.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Lmc\Steward\Console\EventListener;
+
+use Lmc\Steward\Console\CommandEvents;
+use Lmc\Steward\Console\Event\BasicConsoleEvent;
+use Lmc\Steward\Console\Event\ExtendedConsoleEvent;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Invoke clean command before run command starts (unless no-clean option is given)
+ */
+class CleanLogsListener implements EventSubscriberInterface
+{
+    const OPTION_NO_CLEAN = 'no-clean';
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            CommandEvents::CONFIGURE => 'onCommandConfigure',
+            CommandEvents::RUN_TESTS_INIT => 'onCommandRunTestsInit',
+        ];
+    }
+
+    /**
+     * Add option to `run` command configuration.
+     *
+     * @param BasicConsoleEvent $event
+     */
+    public function onCommandConfigure(BasicConsoleEvent $event)
+    {
+        if ($event->getCommand()->getName() != 'run') {
+            return;
+        }
+
+        $event->getCommand()->addOption(
+            self::OPTION_NO_CLEAN,
+            null,
+            InputOption::VALUE_NONE,
+            'Do not clean content of logs directory on startup'
+        );
+    }
+
+    /**
+     * @param ExtendedConsoleEvent $event
+     */
+    public function onCommandRunTestsInit(ExtendedConsoleEvent $event)
+    {
+        if ($event->getInput()->getOption(self::OPTION_NO_CLEAN)) {
+            return;
+        }
+
+        $cleanCommand = $event->getCommand()->getApplication()->find('clean');
+        $cleanCommand->run(new StringInput(''), $event->getOutput());
+    }
+}

--- a/src/Console/EventListener/XdebugListener.php
+++ b/src/Console/EventListener/XdebugListener.php
@@ -29,6 +29,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class XdebugListener implements EventSubscriberInterface
 {
+    const OPTION_XDEBUG = 'xdebug';
+
     /** @var string */
     protected $xdebugIdeKey;
 
@@ -53,7 +55,7 @@ class XdebugListener implements EventSubscriberInterface
         }
 
         $event->getCommand()->addOption(
-            'xdebug',
+            self::OPTION_XDEBUG,
             null,
             InputOption::VALUE_OPTIONAL,
             'Start Xdebug debugger on tests; use given IDE key. Default value is used only if empty option is passed.',
@@ -73,8 +75,8 @@ class XdebugListener implements EventSubscriberInterface
 
         // Use the value of --xdebug only if the option was passed.
         // Don't apply the default if the option was not passed at all.
-        if ($input->getParameterOption('--xdebug') !== false) {
-            $this->xdebugIdeKey = $input->getOption('xdebug');
+        if ($input->getParameterOption('--' . self::OPTION_XDEBUG) !== false) {
+            $this->xdebugIdeKey = $input->getOption(self::OPTION_XDEBUG);
         }
 
         if ($this->xdebugIdeKey) {


### PR DESCRIPTION
See #63 and #67. Should be merged after #65.

The clean command is automatically invoked on `run` command startup, unless option `--no-clean` is given.
