### PR TITLE
Added shortcut -i to invoke --ignore-delays option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- Shortcut `-i` to invoke `--ignore-delays` option.
+
 ### Changed
 - Prepare removal of deprecated features - show deprecation warning when `run-tests` alias is being used. Note this alias and also non-namespaced WebDriver (deprecated in 1.2.0) will be removed in future Steward versions!
 

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -152,7 +152,7 @@ class RunCommand extends Command
             )
             ->addOption(
                 self::OPTION_IGNORE_DELAYS,
-                null,
+                'i',
                 InputOption::VALUE_NONE,
                 'Ignore delays defined between testcases'
             );


### PR DESCRIPTION
When starting Steward locally, one often needs to ignore the delays, and typing the whole options is not that easy :-).
