### PR TITLE
Use OutputStyle to unify Steward output; prefix process output with class name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - mkdir -p src-tests/coverage/
 
 script:
+  - stty cols 120
   - cd src-tests && ../vendor/bin/phpunit --coverage-clover ./logs/clover.xml
   - cd .. && vendor/bin/phpcs --standard=ruleset.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 - Content of directory with logs is cleaned before `run` command starts by default. This could be suppressed using `--no-clean` option of the `run` command. ([#63](https://github.com/lmc-eu/steward/issues/63))
 - Directory for logs is automatically created if it does not exist. ([#67](https://github.com/lmc-eu/steward/issues/67))
+- Process output printed to console (when using `-vv` or `-vvv`) is now prefixed with class name
 
 ## 1.5.0 - 2016-05-05
 ### Added

--- a/src-tests/Console/Style/Fixtures/error.txt
+++ b/src-tests/Console/Style/Fixtures/error.txt
@@ -1,0 +1,3 @@
+
+ [ERROR] Error message                                                                                                  
+

--- a/src-tests/Console/Style/Fixtures/section.txt
+++ b/src-tests/Console/Style/Fixtures/section.txt
@@ -1,0 +1,3 @@
+
+Section header
+--------------

--- a/src-tests/Console/Style/Fixtures/success.txt
+++ b/src-tests/Console/Style/Fixtures/success.txt
@@ -1,0 +1,3 @@
+
+ [OK] Success message                                                                                                   
+

--- a/src-tests/Console/Style/StewardStyleTest.php
+++ b/src-tests/Console/Style/StewardStyleTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Lmc\Steward\Console\Style;
+
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class StewardStyleTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var StewardStyle */
+    protected $style;
+    /** @var BufferedOutput */
+    protected $outputBuffer;
+
+    public function setUp()
+    {
+        $input = new StringInput('');
+        $this->outputBuffer = new BufferedOutput();
+
+        $this->style = new StewardStyle($input, $this->outputBuffer);
+        $this->forceLineLength($this->style);
+    }
+
+    /**
+     * @dataProvider runStatusProvider
+     * @param string $method
+     */
+    public function testShouldFormatRunStatusWithTimestamp($method)
+    {
+        call_user_func([$this->style, $method], 'Foo bar');
+
+        $output = $this->outputBuffer->fetch();
+        $this->assertRegExp('/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]/', $output);
+        $this->assertContains('Foo bar', $output);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function runStatusProvider()
+    {
+        return [
+            ['runStatus'],
+            ['runStatusSuccess'],
+            ['runStatusError'],
+        ];
+    }
+
+    public function testShouldFormatSection()
+    {
+        $this->style->section('Section header');
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixtures/section.txt', $this->outputBuffer->fetch());
+    }
+
+    public function testShouldFormatOutputWithExtraColors()
+    {
+        $input = new StringInput('');
+        $outputMock = $this->getMockBuilder(BufferedOutput::class)
+            ->setMethods(['write', 'writeln'])
+            ->getMock();
+
+        $outputMock->expects($this->at(0))
+            ->method('write')
+            ->with('Foo\Bar> ');
+
+        $outputMock->expects($this->at(1))
+            ->method('writeln')
+            ->with('Basic output');
+
+        $outputMock->expects($this->at(2))
+            ->method('write')
+            ->with('Foo\Bar> ');
+
+        $outputMock->expects($this->at(3))
+            ->method('writeln')
+            ->with('<fg=black;bg=yellow>[WARN] Warning output</fg=black;bg=yellow>');
+
+        $outputMock->expects($this->at(4))
+            ->method('write')
+            ->with('Foo\Bar> ');
+
+        $outputMock->expects($this->at(5))
+            ->method('writeln')
+            ->with('<comment>[DEBUG] Debug output</comment>');
+
+        $style = new StewardStyle($input, $outputMock);
+        $this->forceLineLength($style);
+
+        $rawOutput = <<<HTXT
+Basic output
+[WARN] Warning output
+[DEBUG] Debug output
+HTXT;
+
+        $style->output($rawOutput, 'Foo\Bar');
+    }
+
+    public function testShouldFormatErrorOutput()
+    {
+        $input = new StringInput('');
+        $outputMock = $this->getMockBuilder(BufferedOutput::class)
+            ->setMethods(['write', 'writeln'])
+            ->getMock();
+
+        $outputMock->expects($this->exactly(1))
+            ->method('write')
+            ->with('<error>Foo\Bar ERR> ');
+
+        $outputMock->expects($this->exactly(1))
+            ->method('writeln')
+            ->with('Error output with trailing whitespace</>');
+
+        $style = new StewardStyle($input, $outputMock);
+        $this->forceLineLength($style);
+
+        $rawOutput = <<<HTXT
+Error output with trailing whitespace
+
+
+HTXT;
+
+        $style->errorOutput($rawOutput, 'Foo\Bar');
+    }
+
+    public function testShouldNotProduceOutputForEmptyOutput()
+    {
+        $this->style->output('', 'Foo');
+        $this->assertEmpty($this->outputBuffer->fetch());
+    }
+
+    public function testShouldNotProduceOutputForEmptyErrorOutput()
+    {
+        $this->style->errorOutput('', 'Foo');
+        $this->assertEmpty($this->outputBuffer->fetch());
+    }
+
+    public function testShouldFormatText()
+    {
+        $this->style->text('Text message');
+
+        $this->assertSame("Text message\n", $this->outputBuffer->fetch());
+    }
+
+    public function testShouldFormatSuccess()
+    {
+        $this->style->success('Success message');
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixtures/success.txt', $this->outputBuffer->fetch());
+    }
+
+    public function testShouldFormatError()
+    {
+        $this->style->error('Error message');
+
+        $this->assertStringEqualsFile(__DIR__ . '/Fixtures/error.txt', $this->outputBuffer->fetch());
+    }
+
+    /**
+     * @dataProvider notImplementedProvider
+     * @param string $method
+     * @param array $args
+     */
+    public function testShouldThrowExceptionOnNotImplementedMethods($method, array $args)
+    {
+        $this->setExpectedException(\Exception::class, 'Method not implemented');
+
+        call_user_func_array([$this->style, $method], $args);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function notImplementedProvider()
+    {
+        return [
+            ['title', ['foo']],
+            ['listing', [['foo', 'bar']]],
+            ['warning', ['foo']],
+            ['note', ['foo']],
+            ['caution', ['foo']],
+            ['table', [[], []]],
+            ['ask', ['foo']],
+            ['askHidden', ['foo']],
+            ['confirm', ['foo']],
+            ['choice', ['foo', []]],
+            ['progressStart', []],
+            ['progressAdvance', []],
+            ['progressAdvance', []],
+            ['progressFinish', []],
+        ];
+    }
+
+    /**
+     * Force the line length to ensure a consistent output for expectations
+     * @param StewardStyle $style
+     */
+    private function forceLineLength(StewardStyle $style)
+    {
+        $symfonyStyleProperty = new \ReflectionProperty(get_class($style), 'symfonyStyle');
+        $symfonyStyleProperty->setAccessible(true);
+        $symfonyStyle = $symfonyStyleProperty->getValue($style);
+
+        $lineLengthProperty = new \ReflectionProperty(get_class($symfonyStyle), 'lineLength');
+        $lineLengthProperty->setAccessible(true);
+        $lineLengthProperty->setValue($symfonyStyle, 120);
+    }
+}

--- a/src/Console/Style/StewardStyle.php
+++ b/src/Console/Style/StewardStyle.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Lmc\Steward\Console\Style;
+
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class StewardStyle extends OutputStyle
+{
+    /** @var SymfonyStyle */
+    protected $symfonyStyle;
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        parent::__construct($output);
+
+        $this->symfonyStyle = new SymfonyStyle($input, $output);
+    }
+
+    /**
+     * Output progress message status
+     * @param string $message
+     */
+    public function runStatus($message)
+    {
+        $this->writeln($this->getTimestamp() . $message);
+    }
+
+    /**
+     * Output success message in progress status
+     * @param string $message
+     */
+    public function runStatusSuccess($message)
+    {
+        $this->runStatus('<fg=green>' . $message . '</>');
+    }
+
+    /**
+     * Output error message in progress status
+     * @param string $message
+     */
+    public function runStatusError($message)
+    {
+        $this->runStatus('<fg=red>' . $message . '</>');
+    }
+
+    public function title($message)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function section($message)
+    {
+        $this->newLine();
+        $this->writeln([
+            sprintf('<comment>%s</>', $message),
+            sprintf(
+                '<comment>%s</>',
+                str_repeat('-', Helper::strlenWithoutDecoration($this->getFormatter(), $message))
+            ),
+        ]);
+    }
+
+    /**
+     * Print output from process
+     *
+     * @param string $output
+     * @param string $identifier
+     */
+    public function output($output, $identifier)
+    {
+        if (empty($output)) {
+            return;
+        }
+
+        $lines = explode("\n", $output);
+
+        foreach ($lines as $line) {
+            // color lines containing "[WARN]" or "[DEBUG]"
+            if (strpos($line, '[WARN]') !== false) {
+                $line = '<fg=black;bg=yellow>' . $line . '</fg=black;bg=yellow>';
+            } elseif (strpos($line, '[DEBUG]') !== false) {
+                $line = '<comment>' . $line . '</comment>';
+            }
+
+            $this->write($identifier . '> ');
+            $this->writeln($line);
+        }
+    }
+
+    /**
+     * Print error output from process
+     *
+     * @param string $output
+     * @param string $identifier
+     */
+    public function errorOutput($output, $identifier)
+    {
+        $output = rtrim($output);
+
+        if (empty($output)) {
+            return;
+        }
+
+        $lines = explode("\n", $output);
+
+        foreach ($lines as $line) {
+            $this->write('<error>' . $identifier . ' ERR> ');
+            $this->writeln($line . '</>');
+        }
+    }
+
+    public function listing(array $elements)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function text($message)
+    {
+        $this->writeln($message);
+    }
+
+    public function success($message)
+    {
+        $this->symfonyStyle->block($message, 'OK', 'fg=black;bg=green', ' ', true);
+    }
+
+    public function error($message)
+    {
+        $this->symfonyStyle->block($message, 'ERROR', 'fg=white;bg=red', ' ', true);
+    }
+
+    public function warning($message)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function note($message)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function caution($message)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function table(array $headers, array $rows)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function ask($question, $default = null, $validator = null)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function askHidden($question, $validator = null)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function confirm($question, $default = true)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function choice($question, array $choices, $default = null)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function progressStart($max = 0)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function progressAdvance($step = 1)
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    public function progressFinish()
+    {
+        throw new \Exception('Method not implemented');
+    }
+
+    /**
+     * @return string
+     */
+    private function getTimestamp()
+    {
+        return '[' . date("Y-m-d H:i:s") . '] ';
+    }
+}

--- a/src/Process/ProcessWrapper.php
+++ b/src/Process/ProcessWrapper.php
@@ -189,8 +189,7 @@ class ProcessWrapper
         } catch (ProcessTimedOutException $e) {
             $this->setStatus(self::PROCESS_STATUS_DONE);
             return sprintf(
-                '[%s]: Process for class "%s" exceeded the timeout of %d seconds and was killed.',
-                date("Y-m-d H:i:s"),
+                'Process for class "%s" exceeded the timeout of %d seconds and was killed.',
                 $this->getClassName(),
                 $e->getExceededTimeout()
             );


### PR DESCRIPTION
Output from processes printed to the console is now prefixed with class name.

Output from Steward during test execution is now also prefixed with timestamp.

All output from the executionLoop is done using $io, not by using $output. This will also allow better executionLoop refactoring in #61.

Ref. #62.
