### PR TITLE
Support SauceLabs and BrowserStack cloud services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).
 - Command `clean` to remove old content of logs directory (previous png screenshots, HTML snapshots and JUnit xmls).
 - Option `--capability` to `run` command which allows to simply pass any custom DesiredCapabilities to the WebDriver server.
+- Support for cloud services like [SauceLabs](https://saucelabs.com/) or [BrowserStack](https://www.browserstack.com/) - simply pass remote server URL (including credentials) using `--server-url`.
+- If [SauceLabs](https://saucelabs.com/) is used as remote cloud platform, test results are automatically published to SauceLabs API when test is done.
 
 ### Changed
 - Content of directory with logs is cleaned before `run` command starts by default. This could be suppressed using `--no-clean` option of the `run` command. ([#63](https://github.com/lmc-eu/steward/issues/63))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 ### Changed
 - Content of directory with logs is cleaned before `run` command starts by default. This could be suppressed using `--no-clean` option of the `run` command. ([#63](https://github.com/lmc-eu/steward/issues/63))
 - Directory for logs is automatically created if it does not exist. ([#67](https://github.com/lmc-eu/steward/issues/67))
-- Process output printed to console (when using `-vv` or `-vvv`) is now prefixed with class name
+- Process output printed to console (when using `-vv` or `-vvv`) is now prefixed with class name.
+- BC: Pass instance of current PHPUnit test as third parameter of `publishResult()` method of `AbstractPublisher` descendants.
 
 ### Fixed
 - Parsing of latest Selenium server version in `install` command so that even Selenium 3 beta releases are installed ([#76](https://github.com/lmc-eu/steward/pull/76))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).
 - Command `clean` to remove old content of logs directory (previous png screenshots, HTML snapshots and JUnit xmls).
+- Option `--capability` to `run` command which allows to simply pass any custom DesiredCapabilities to the WebDriver server.
 
 ### Changed
 - Content of directory with logs is cleaned before `run` command starts by default. This could be suppressed using `--no-clean` option of the `run` command. ([#63](https://github.com/lmc-eu/steward/issues/63))

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "florianwolters/component-util-singleton": "0.3.2",
         "caseyamcl/configula": "~2.3",
         "doctrine/inflector": "~1.0",
-        "beberlei/assert": "^2.4"
+        "beberlei/assert": "^2.4",
+        "ondram/ci-detector": "^0.3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.4.1",

--- a/src-tests/ConfigHelper.php
+++ b/src-tests/ConfigHelper.php
@@ -28,6 +28,7 @@ class ConfigHelper
             'BROWSER_NAME' => 'firefox',
             'ENV' => 'testing',
             'SERVER_URL' => 'http://server.tld:port',
+            'CAPABILITY' => '',
             'PUBLISH_RESULTS' => 0,
             'FIXTURES_DIR' => __DIR__,
             'LOGS_DIR' => __DIR__,

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -174,11 +174,12 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function testShouldStopIfServerIsNotResponding()
     {
         $seleniumAdapterMock = $this->getMockBuilder(SeleniumServerAdapter::class)
+            ->setConstructorArgs(['http://foo.bar:1337'])
+            ->setMethods(['isAccessible', 'getLastError'])
             ->getMock();
 
         $seleniumAdapterMock->expects($this->once())
             ->method('isAccessible')
-            ->with('http://foo.bar:1337')
             ->willReturn(false);
 
         $seleniumAdapterMock->expects($this->once())
@@ -206,6 +207,8 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function testShouldStopIfServerIsRespondingButIsNotSelenium()
     {
         $seleniumAdapterMock = $this->getMockBuilder(SeleniumServerAdapter::class)
+            ->setConstructorArgs(['http://foo.bar:1337'])
+            ->setMethods(['isAccessible', 'isSeleniumServer', 'getLastError'])
             ->getMock();
 
         $seleniumAdapterMock->expects($this->once())
@@ -214,7 +217,6 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $seleniumAdapterMock->expects($this->once())
             ->method('isSeleniumServer')
-            ->with('http://foo.bar:1337')
             ->willReturn(false);
 
         $seleniumAdapterMock->expects($this->once())
@@ -271,6 +273,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $application = new Application();
         $application->add(new RunCommand($dispatcherMock));
+        /** @var RunCommand $command */
         $command = $application->find('run');
         $command->setSeleniumAdapter($this->getSeleniumAdapterMock());
 
@@ -291,6 +294,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $application = new Application();
         $application->add(new RunCommand($dispatcherMock));
+        /** @var RunCommand $command */
         $command = $application->find('run');
         $command->setSeleniumAdapter($this->getSeleniumAdapterMock());
 
@@ -380,6 +384,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     protected function getSeleniumAdapterMock()
     {
         $seleniumAdapterMock = $this->getMockBuilder(SeleniumServerAdapter::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $seleniumAdapterMock->expects($this->any())

--- a/src-tests/Publisher/SauceLabsPublisherTest.php
+++ b/src-tests/Publisher/SauceLabsPublisherTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Lmc\Steward\Publisher;
+
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Lmc\Steward\ConfigHelper;
+use Lmc\Steward\Test\AbstractTestCaseBase;
+use Lmc\Steward\WebDriver\NullWebDriver;
+use phpmock\phpunit\PHPMock;
+
+/**
+ * @covers Lmc\Steward\Publisher\SauceLabsPublisher
+ */
+class SauceLabsPublisherTest extends \PHPUnit_Framework_TestCase
+{
+    use PHPMock;
+
+    /** @var SauceLabsPublisher */
+    protected $publisher;
+    /** @var \PHPUnit_Framework_MockObject_MockObject|AbstractTestCaseBase */
+    protected $testInstanceMock;
+
+    public function setUp()
+    {
+        $configValues = ConfigHelper::getDummyConfig();
+        $configValues['SERVER_URL'] = 'http://username:pass@ondemand.saucelabs.com:80';
+        ConfigHelper::setEnvironmentVariables($configValues);
+        ConfigHelper::unsetConfigInstance();
+
+        $this->publisher = new SauceLabsPublisher();
+        $this->testInstanceMock = $this->getMockBuilder(AbstractTestCaseBase::class)
+            ->getMock();
+    }
+
+    public function testShouldDoNothingWhenPublishingTestcaseResults()
+    {
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResults('testCaseName', AbstractPublisher::TEST_STATUS_DONE);
+    }
+
+    public function testShouldDoNothingIfTestStatusIsNotDone()
+    {
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_STARTED
+        );
+    }
+
+    public function testShouldDoNothingIfTestResultIsSkippedOrIncomplete()
+    {
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_SKIPPED
+        );
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_INCOMPLETE
+        );
+    }
+
+    public function testShouldDoNothingIfTestContainsInstanceOfNullWebdriver()
+    {
+        $this->testInstanceMock->wd = new NullWebDriver();
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE
+        );
+    }
+
+    public function testShouldPublishTestResult()
+    {
+        $this->testInstanceMock->wd = $this->getMockBuilder(RemoteWebDriver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->once())
+            ->with('https://saucelabs.com/rest/v1/username/jobs/');
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
+        $curlInitMock->expects($this->any());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_exec');
+        $curlInitMock->expects($this->once());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_errno');
+        $curlInitMock->expects($this->once())
+            ->willReturn(false);
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_close');
+        $curlInitMock->expects($this->once());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_FAILED
+        );
+    }
+
+    public function testShouldThrowExceptionIfPublishToApiFailed()
+    {
+        $this->testInstanceMock->wd = $this->getMockBuilder(RemoteWebDriver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->any());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
+        $curlInitMock->expects($this->any());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_exec');
+        $curlInitMock->expects($this->once());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_errno');
+        $curlInitMock->expects($this->once())
+            ->willReturn(333);
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_error');
+        $curlInitMock->expects($this->once())
+            ->willReturn('omg wtf');
+
+        $this->setExpectedException(
+            \Exception::class,
+            'Error publishing results of test testBar to SauceLabs API: omg wtf'
+        );
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_PASSED
+        );
+    }
+}

--- a/src-tests/Publisher/XmlPublisherTest.php
+++ b/src-tests/Publisher/XmlPublisherTest.php
@@ -8,6 +8,8 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
 {
     /** @var XmlPublisher */
     protected $publisher;
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\PHPUnit_Framework_Test */
+    protected $testInstanceMock;
 
     public function setUp()
     {
@@ -17,6 +19,8 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         ConfigHelper::unsetConfigInstance();
 
         $this->publisher = new XmlPublisher();
+        $this->testInstanceMock = $this->getMockBuilder(\PHPUnit_Framework_Test::class)
+            ->getMock();
     }
 
     public static function tearDownAfterClass()
@@ -73,7 +77,7 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldNotAllowToPublishUnknownTestStatus()
     {
-        $this->publisher->publishResult('testCaseName', 'testName', 'unknownStatus');
+        $this->publisher->publishResult('testCaseName', 'testName', $this->testInstanceMock, 'unknownStatus');
     }
 
     /**
@@ -82,7 +86,13 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldNotAllowToPublishUnknownTestResult()
     {
-        $this->publisher->publishResult('testCaseName', 'testName', 'started', 'unknownResult');
+        $this->publisher->publishResult(
+            'testCaseName',
+            'testName',
+            $this->testInstanceMock,
+            'started',
+            'unknownResult'
+        );
     }
 
     /**
@@ -92,7 +102,7 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
     {
         $fileName = $this->createEmptyFile();
 
-        $this->publisher->publishResult('testCaseNameFoo', 'testNameBar', 'started');
+        $this->publisher->publishResult('testCaseNameFoo', 'testNameBar', $this->testInstanceMock, 'started');
 
         /** @var \SimpleXMLElement $xml */
         $xml = simplexml_load_file($fileName);
@@ -128,7 +138,7 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         file_put_contents($fileName, $xml);
 
         $this->publisher->setFileName(basename($fileName));
-        $this->publisher->publishResult('testCaseNameFoo', 'testNameBar', 'done', 'passed');
+        $this->publisher->publishResult('testCaseNameFoo', 'testNameBar', $this->testInstanceMock, 'done', 'passed');
 
         /** @var \SimpleXMLElement $xml */
         $xml = simplexml_load_file($fileName);
@@ -208,7 +218,7 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         ConfigHelper::unsetConfigInstance();
 
         $publisher = new XmlPublisher();
-        $publisher->publishResult('testCaseNameFoo', 'testNameBar', 'started');
+        $publisher->publishResult('testCaseNameFoo', 'testNameBar', $this->testInstanceMock, 'started');
     }
 
     public function testShouldNotOverwriteTestsWithSameName()
@@ -216,10 +226,22 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         $fileName = $this->createEmptyFile();
 
         // create first record for testFoo
-        $this->publisher->publishResult('testCaseNameFoo', 'testFoo', 'done', XmlPublisher::TEST_RESULT_PASSED);
+        $this->publisher->publishResult(
+            'testCaseNameFoo',
+            'testFoo',
+            $this->testInstanceMock,
+            'done',
+            XmlPublisher::TEST_RESULT_PASSED
+        );
 
         // create first record for testFoo, but in different testcase
-        $this->publisher->publishResult('testCaseNameBar', 'testFoo', 'done', XmlPublisher::TEST_RESULT_PASSED);
+        $this->publisher->publishResult(
+            'testCaseNameBar',
+            'testFoo',
+            $this->testInstanceMock,
+            'done',
+            XmlPublisher::TEST_RESULT_PASSED
+        );
 
         /** @var \SimpleXMLElement $xml */
         $xml = simplexml_load_file($fileName);
@@ -242,7 +264,12 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         $fileName = $this->createEmptyFile();
 
         // Add "started" record of the test
-        $this->publisher->publishResult($testCaseName, $testName, XmlPublisher::TEST_STATUS_STARTED);
+        $this->publisher->publishResult(
+            $testCaseName,
+            $testName,
+            $this->testInstanceMock,
+            XmlPublisher::TEST_STATUS_STARTED
+        );
 
         /** @var \SimpleXMLElement $xml */
         $xml = simplexml_load_file($fileName);
@@ -258,6 +285,7 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         $this->publisher->publishResult(
             $testCaseName,
             $testName,
+            $this->testInstanceMock,
             XmlPublisher::TEST_STATUS_DONE,
             XmlPublisher::TEST_RESULT_PASSED
         );

--- a/src-tests/Selenium/Fixtures/response-browserstack.json
+++ b/src-tests/Selenium/Fixtures/response-browserstack.json
@@ -1,0 +1,12 @@
+{
+  "status": 0,
+  "sessionId": null,
+  "value": {
+    "build": {
+      "time": "2015-02-26 23:59:50",
+      "version": "2.45.0",
+      "revision": "5017cb8"
+    }
+  },
+  "state": "success"
+}

--- a/src-tests/Selenium/Fixtures/response-grid.json
+++ b/src-tests/Selenium/Fixtures/response-grid.json
@@ -1,0 +1,153 @@
+{
+  "status": 13,
+  "value": {
+    "message": "Session [(null externalkey)] not available and is not among the last 1000 terminated sessions.\nActive sessions are[]",
+    "class": "org.openqa.grid.common.exception.GridException",
+    "stackTrace": [
+      {
+        "fileName": "ActiveTestSessions.java",
+        "className": "org.openqa.grid.internal.ActiveTestSessions",
+        "methodName": "getExistingSession",
+        "lineNumber": 110
+      },
+      {
+        "fileName": "Registry.java",
+        "className": "org.openqa.grid.internal.Registry",
+        "methodName": "getExistingSession",
+        "lineNumber": 425
+      },
+      {
+        "fileName": "RequestHandler.java",
+        "className": "org.openqa.grid.web.servlet.handler.RequestHandler",
+        "methodName": "getSession",
+        "lineNumber": 240
+      },
+      {
+        "fileName": "RequestHandler.java",
+        "className": "org.openqa.grid.web.servlet.handler.RequestHandler",
+        "methodName": "process",
+        "lineNumber": 120
+      },
+      {
+        "fileName": "DriverServlet.java",
+        "className": "org.openqa.grid.web.servlet.DriverServlet",
+        "methodName": "process",
+        "lineNumber": 83
+      },
+      {
+        "fileName": "DriverServlet.java",
+        "className": "org.openqa.grid.web.servlet.DriverServlet",
+        "methodName": "doGet",
+        "lineNumber": 61
+      },
+      {
+        "fileName": "HttpServlet.java",
+        "className": "javax.servlet.http.HttpServlet",
+        "methodName": "service",
+        "lineNumber": 687
+      },
+      {
+        "fileName": "HttpServlet.java",
+        "className": "javax.servlet.http.HttpServlet",
+        "methodName": "service",
+        "lineNumber": 790
+      },
+      {
+        "fileName": "ServletHolder.java",
+        "className": "org.seleniumhq.jetty9.servlet.ServletHolder",
+        "methodName": "handle",
+        "lineNumber": 808
+      },
+      {
+        "fileName": "ServletHandler.java",
+        "className": "org.seleniumhq.jetty9.servlet.ServletHandler",
+        "methodName": "doHandle",
+        "lineNumber": 587
+      },
+      {
+        "fileName": "SessionHandler.java",
+        "className": "org.seleniumhq.jetty9.server.session.SessionHandler",
+        "methodName": "doHandle",
+        "lineNumber": 221
+      },
+      {
+        "fileName": "ContextHandler.java",
+        "className": "org.seleniumhq.jetty9.server.handler.ContextHandler",
+        "methodName": "doHandle",
+        "lineNumber": 1127
+      },
+      {
+        "fileName": "ServletHandler.java",
+        "className": "org.seleniumhq.jetty9.servlet.ServletHandler",
+        "methodName": "doScope",
+        "lineNumber": 515
+      },
+      {
+        "fileName": "SessionHandler.java",
+        "className": "org.seleniumhq.jetty9.server.session.SessionHandler",
+        "methodName": "doScope",
+        "lineNumber": 185
+      },
+      {
+        "fileName": "ContextHandler.java",
+        "className": "org.seleniumhq.jetty9.server.handler.ContextHandler",
+        "methodName": "doScope",
+        "lineNumber": 1061
+      },
+      {
+        "fileName": "ScopedHandler.java",
+        "className": "org.seleniumhq.jetty9.server.handler.ScopedHandler",
+        "methodName": "handle",
+        "lineNumber": 141
+      },
+      {
+        "fileName": "HandlerWrapper.java",
+        "className": "org.seleniumhq.jetty9.server.handler.HandlerWrapper",
+        "methodName": "handle",
+        "lineNumber": 97
+      },
+      {
+        "fileName": "Server.java",
+        "className": "org.seleniumhq.jetty9.server.Server",
+        "methodName": "handle",
+        "lineNumber": 499
+      },
+      {
+        "fileName": "HttpChannel.java",
+        "className": "org.seleniumhq.jetty9.server.HttpChannel",
+        "methodName": "handle",
+        "lineNumber": 310
+      },
+      {
+        "fileName": "HttpConnection.java",
+        "className": "org.seleniumhq.jetty9.server.HttpConnection",
+        "methodName": "onFillable",
+        "lineNumber": 257
+      },
+      {
+        "fileName": "AbstractConnection.java",
+        "className": "org.seleniumhq.jetty9.io.AbstractConnection$2",
+        "methodName": "run",
+        "lineNumber": 540
+      },
+      {
+        "fileName": "QueuedThreadPool.java",
+        "className": "org.seleniumhq.jetty9.util.thread.QueuedThreadPool",
+        "methodName": "runJob",
+        "lineNumber": 635
+      },
+      {
+        "fileName": "QueuedThreadPool.java",
+        "className": "org.seleniumhq.jetty9.util.thread.QueuedThreadPool$3",
+        "methodName": "run",
+        "lineNumber": 555
+      },
+      {
+        "fileName": "Thread.java",
+        "className": "java.lang.Thread",
+        "methodName": "run",
+        "lineNumber": 745
+      }
+    ]
+  }
+}

--- a/src-tests/Selenium/Fixtures/response-saucelabs.json
+++ b/src-tests/Selenium/Fixtures/response-saucelabs.json
@@ -1,0 +1,15 @@
+{
+  "status": 0,
+  "sessionId": null,
+  "value": {
+    "build": {
+      "version": "Sauce Labs"
+    },
+    "details": {
+      "status": "available",
+      "jobWait": 0,
+      "details": "Sauce Labs automated testing is fully operational",
+      "souschefs_online": true
+    }
+  }
+}

--- a/src-tests/Selenium/Fixtures/response-standalone.json
+++ b/src-tests/Selenium/Fixtures/response-standalone.json
@@ -1,0 +1,22 @@
+{
+  "state": "success",
+  "sessionId": null,
+  "hCode": 1526144543,
+  "value": {
+    "build": {
+      "version": "2.53.1",
+      "revision": "a36b8b1",
+      "time": "2016-06-30 17:37:03"
+    },
+    "os": {
+      "name": "Linux",
+      "arch": "amd64",
+      "version": "4.6.4-1-ARCH"
+    },
+    "java": {
+      "version": "1.8.0_102"
+    }
+  },
+  "class": "org.openqa.selenium.remote.Response",
+  "status": 0
+}

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -15,7 +15,85 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->adapter = new SeleniumServerAdapter();
+        $this->adapter = new SeleniumServerAdapter($this->serverUrl);
+    }
+
+    public function testShouldGetParsedServerUrlParts()
+    {
+        $adapter = new SeleniumServerAdapter('https://user:pass@host:1337/selenium?foo=bar');
+
+        $this->assertSame(
+            [
+                'scheme' => 'https',
+                'host' => 'host',
+                'port' => 1337,
+                'user' => 'user',
+                'pass' => 'pass',
+                'path' => '/selenium',
+                'query' => 'foo=bar',
+            ],
+            $adapter->getServerUrlParts()
+        );
+    }
+
+    /**
+     * @dataProvider serverUrlProvider
+     * @param string $providedServerUrl
+     * @param string $expectedServerUrl
+     */
+    public function testShouldGetServerUrlWithDefaultPortIfNeeded($providedServerUrl, $expectedServerUrl)
+    {
+        $adapter = new SeleniumServerAdapter($providedServerUrl);
+
+        $this->assertSame($expectedServerUrl, $adapter->getServerUrl());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function serverUrlProvider()
+    {
+        return [
+            'protocol, host and port' => ['http://foo:80', 'http://foo:80'],
+            'local URL with specified port should keep it' => ['http://localhost:4444', 'http://localhost:4444'],
+            'local URL without port should use 4444' => ['http://localhost', 'http://localhost:4444'],
+            'cloud service URL with port should keep it' =>
+                ['http://foo:bar@ondemand.saucelabs.com:1337', 'http://foo:bar@ondemand.saucelabs.com:1337'],
+            'cloud service URL without port should use 80' =>
+                ['http://foo:bar@ondemand.saucelabs.com', 'http://foo:bar@ondemand.saucelabs.com:80'],
+            'non-cloud URL without port should use 4444' => ['http://foo.com', 'http://foo.com:4444'],
+            'username and host should get deault port' => ['http://user@foo', 'http://user@foo:4444'],
+            'all parts' =>
+                ['https://user:pass@host:1337/selenium?foo=bar', 'https://user:pass@host:1337/selenium?foo=bar'],
+            'all parts expects port should get default port' =>
+                ['https://user:pass@host/selenium?foo=bar', 'https://user:pass@host:4444/selenium?foo=bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidServerUrlProvider
+     * @param string $serverUrl
+     */
+    public function testShouldThrowExceptionIfInvalidServerUrlIsGiven($serverUrl)
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'Provided Selenium server URL "' . $serverUrl . '" is invalid'
+        );
+
+        new SeleniumServerAdapter($serverUrl);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function invalidServerUrlProvider()
+    {
+        return [
+            ['http://'],
+            [''],
+            ['foo'],
+        ];
     }
 
     public function testShouldReturnTrueIfUrlIsAccessible()
@@ -27,7 +105,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
             ->with('selenium.local', '1337')
             ->willReturn($dummyResource);
 
-        $this->assertTrue($this->adapter->isAccessible($this->serverUrl));
+        $this->assertTrue($this->adapter->isAccessible());
     }
 
     public function testShouldReturnFalseIfConnectionIsRefused()
@@ -40,7 +118,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
                 $connectionError = 'Connection refused';
             });
 
-        $this->assertFalse($this->adapter->isAccessible($this->serverUrl));
+        $this->assertFalse($this->adapter->isAccessible());
         $this->assertEquals('Connection refused', $this->adapter->getLastError());
     }
 
@@ -51,7 +129,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
             ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn(false);
 
-        $this->assertFalse($this->adapter->isSeleniumServer($this->serverUrl));
+        $this->assertFalse($this->adapter->isSeleniumServer());
         $this->assertEquals('error reading server response', $this->adapter->getLastError());
     }
 
@@ -62,7 +140,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
             ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn('THIS IS NOT JSON');
 
-        $this->assertFalse($this->adapter->isSeleniumServer($this->serverUrl));
+        $this->assertFalse($this->adapter->isSeleniumServer());
         $this->assertRegExp('/^error parsing server JSON response \(.+\)$/', $this->adapter->getLastError());
     }
 
@@ -78,7 +156,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
                 . '"java":{"version":"1.7.0_79"}},"class":"org.openqa.selenium.remote.Response","hCode":27226235}'
             );
 
-        $this->assertTrue($this->adapter->isSeleniumServer($this->serverUrl));
+        $this->assertTrue($this->adapter->isSeleniumServer());
         $this->assertEmpty($this->adapter->getLastError());
     }
 
@@ -95,7 +173,31 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
                 . '"lineNumber":745}]}}'
             );
 
-        $this->assertTrue($this->adapter->isSeleniumServer($this->serverUrl));
+        $this->assertTrue($this->adapter->isSeleniumServer());
         $this->assertEmpty($this->adapter->getLastError());
+    }
+
+    /**
+     * @dataProvider cloudServiceProvider
+     * @param string $serverUrl
+     * @param bool $isCloudService
+     */
+    public function testShouldDetectCloudServices($serverUrl, $isCloudService)
+    {
+        $adapter = new SeleniumServerAdapter($serverUrl);
+
+        $this->assertSame($isCloudService, $adapter->isCloudService());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function cloudServiceProvider()
+    {
+        return [
+            'SauceLabs cloud service' => ['http://foo:bar@ondemand.saucelabs.com:80', true],
+            'BrowserStack cloud service' => ['http://bar:baz@hub-cloud.browserstack.com:80', true],
+            'non-cloud host' => ['http://foobar.com', false],
+        ];
     }
 }

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -48,7 +48,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $fileGetContentsMock = $this->getFunctionMock(__NAMESPACE__, 'file_get_contents');
         $fileGetContentsMock->expects($this->once())
-            ->with($this->serverUrl . '/wd/hub/status/')
+            ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn(false);
 
         $this->assertFalse($this->adapter->isSeleniumServer($this->serverUrl));
@@ -59,7 +59,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $fileGetContentsMock = $this->getFunctionMock(__NAMESPACE__, 'file_get_contents');
         $fileGetContentsMock->expects($this->once())
-            ->with($this->serverUrl . '/wd/hub/status/')
+            ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn('THIS IS NOT JSON');
 
         $this->assertFalse($this->adapter->isSeleniumServer($this->serverUrl));
@@ -70,7 +70,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $fileGetContentsMock = $this->getFunctionMock(__NAMESPACE__, 'file_get_contents');
         $fileGetContentsMock->expects($this->once())
-            ->with($this->serverUrl . '/wd/hub/status/')
+            ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn(
                 '{"sessionId":null,"status":0,"state":"success",'
                 . '"value":{"build":{"version":"2.45.0","revision":"5017cb8","time":"2015-02-26 23:59:50"},'
@@ -86,7 +86,7 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $fileGetContentsMock = $this->getFunctionMock(__NAMESPACE__, 'file_get_contents');
         $fileGetContentsMock->expects($this->once())
-            ->with($this->serverUrl . '/wd/hub/status/')
+            ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn(
                 '{"status":13,"value":{"message":"Session [(null externalkey)] not available and is not among the'
                 . ' last 1000 terminated sessions.\nActive sessions are[]",'

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -13,6 +13,7 @@ use FlorianWolters\Component\Util\Singleton\SingletonTrait;
  * @property-read string browserName
  * @property-read string env
  * @property-read string serverUrl
+ * @property-read string capability
  * @property-read string publishResults
  * @property-read string fixturesDir
  * @property-read string logsDir
@@ -92,6 +93,7 @@ class ConfigProvider
             'BROWSER_NAME',
             'ENV',
             'SERVER_URL',
+            'CAPABILITY',
             'PUBLISH_RESULTS',
             'FIXTURES_DIR',
             'LOGS_DIR',
@@ -105,7 +107,7 @@ class ConfigProvider
     }
 
     /**
-     * Retrieve given configuration options values from environment If value is not found, throw and exception.
+     * Retrieve given configuration options values from environment. If value is not found, throw and exception.
      *
      * @throws \RuntimeException
      * @param array $options

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -35,28 +35,4 @@ class Command extends \Symfony\Component\Console\Command\Command
     {
         return $this->dispatcher;
     }
-
-    /**
-     * Check if current environment is CI server.
-     *
-     * @codeCoverageIgnore The environment variables behavior is untestable
-     * @return bool|string False if not an CI server, name of the CI server otherwise
-     */
-    protected function isCi()
-    {
-        $ciEnvVariables = [
-            'JENKINS_URL' => 'Jenkins CI',
-            'TRAVIS' => 'Travis CI',
-            'CIRCLECI' => 'CircleCI',
-            'TEAMCITY_VERSION ' => 'TeamCity',
-        ];
-
-        foreach ($ciEnvVariables as $variable => $ciName) {
-            if (getenv($variable)) {
-                return $ciName;
-            }
-        }
-
-        return false;
-    }
 }

--- a/src/Console/Command/InstallCommand.php
+++ b/src/Console/Command/InstallCommand.php
@@ -5,6 +5,7 @@ namespace Lmc\Steward\Console\Command;
 use Lmc\Steward\Console\CommandEvents;
 use Lmc\Steward\Console\Event\BasicConsoleEvent;
 use Lmc\Steward\Selenium\Downloader;
+use OndraM\CiDetector;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -106,7 +107,7 @@ class InstallCommand extends Command
                 sprintf(
                     '<info>Steward</info> <comment>%s</comment> is now downloading the Selenium standalone server...%s',
                     $this->getApplication()->getVersion(),
-                    (!$this->isCi() ? ' Just for you <fg=red><3</fg=red>!' : '')
+                    (!CiDetector::detect() ? ' Just for you <fg=red><3</fg=red>!' : '')
                 )
             );
         }

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -43,6 +43,7 @@ class RunCommand extends Command
     const ARGUMENT_ENVIRONMENT = 'environment';
     const ARGUMENT_BROWSER = 'browser';
     const OPTION_SERVER_URL = 'server-url';
+    const OPTION_CAPABILITY = 'capability';
     const OPTION_TESTS_DIR = 'tests-dir';
     const OPTION_FIXTURES_DIR = 'fixtures-dir';
     const OPTION_LOGS_DIR = 'logs-dir';
@@ -93,8 +94,14 @@ class RunCommand extends Command
                 self::OPTION_SERVER_URL,
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Selenium server (hub) hub hostname and port',
+                'Selenium server (hub) hostname and port',
                 'http://localhost:4444'
+            )
+            ->addOption(
+                self::OPTION_CAPABILITY,
+                null,
+                InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+                'Extra DesiredCapabilities to be passed to WebDriver, use format capabilityName:value'
             )
             ->addOption(
                 self::OPTION_TESTS_DIR,

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -94,7 +94,7 @@ class RunCommand extends Command
                 self::OPTION_SERVER_URL,
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Selenium server (hub) hostname and port',
+                'Selenium server (hub) URL (may include port numbe)',
                 'http://localhost:4444'
             )
             ->addOption(
@@ -322,12 +322,13 @@ class RunCommand extends Command
 
     /**
      * @codeCoverageIgnore
+     * @param string $seleniumServerUrl
      * @return SeleniumServerAdapter
      */
-    protected function getSeleniumAdapter()
+    protected function getSeleniumAdapter($seleniumServerUrl)
     {
         if (!$this->seleniumAdapter) {
-            $this->seleniumAdapter = new SeleniumServerAdapter();
+            $this->seleniumAdapter = new SeleniumServerAdapter($seleniumServerUrl);
         }
 
         return $this->seleniumAdapter;
@@ -562,14 +563,14 @@ class RunCommand extends Command
      */
     protected function testSeleniumConnection(StewardStyle $io, $seleniumServerUrl)
     {
-        $seleniumAdapter = $this->getSeleniumAdapter();
+        $seleniumAdapter = $this->getSeleniumAdapter($seleniumServerUrl);
         $io->write(
-            sprintf('Selenium server (hub) url: %s, trying connection...', $seleniumServerUrl),
+            sprintf('Selenium server (hub) url: %s, trying connection...', $seleniumAdapter->getServerUrl()),
             false,
             OutputInterface::VERBOSITY_VERY_VERBOSE
         );
 
-        if (!$seleniumAdapter->isAccessible($seleniumServerUrl)) {
+        if (!$seleniumAdapter->isAccessible()) {
             $io->writeln(
                 sprintf(
                     '<error>%s ("%s")</error>',
@@ -582,14 +583,14 @@ class RunCommand extends Command
                 sprintf(
                     'Make sure your Selenium server is really accessible on url "%s" '
                     . 'or change it using --server-url option',
-                    $seleniumServerUrl
+                    $seleniumAdapter->getServerUrl()
                 )
             );
 
             return false;
         }
 
-        if (!$seleniumAdapter->isSeleniumServer($seleniumServerUrl)) {
+        if (!$seleniumAdapter->isSeleniumServer()) {
             $io->writeln(
                 sprintf(
                     '<error>%s (%s)</error>',
@@ -602,7 +603,7 @@ class RunCommand extends Command
                     'Looks like url "%s" is occupied by something else than Selenium server. '
                     . 'Make sure Selenium server is really accessible on this url '
                     . 'or change it using --server-url option',
-                    $seleniumServerUrl
+                    $seleniumAdapter->getServerUrl()
                 )
             );
 

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -610,7 +610,13 @@ class RunCommand extends Command
             return false;
         }
 
-        $io->writeln('OK', OutputInterface::VERBOSITY_VERY_VERBOSE);
+        if ($io->isVeryVerbose()) {
+            $cloudService = $seleniumAdapter->getCloudService();
+            $io->writeln(
+                'OK' . ($cloudService ? ' (' . $cloudService . ' cloud service detected)' : ''),
+                OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
+        }
 
         return true;
     }

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -13,6 +13,7 @@ use Lmc\Steward\Process\ProcessSetCreator;
 use Lmc\Steward\Process\ProcessWrapper;
 use Lmc\Steward\Publisher\XmlPublisher;
 use Lmc\Steward\Selenium\SeleniumServerAdapter;
+use OndraM\CiDetector;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -180,7 +181,7 @@ class RunCommand extends Command
             sprintf(
                 '<info>Steward</info> <comment>%s</comment> is running the tests...%s',
                 $this->getApplication()->getVersion(),
-                (!$this->isCi() ? ' Just for you <fg=red><3</fg=red>!' : '') // on CI server it is not just for you
+                (!CiDetector::detect() ? ' Just for you <fg=red><3</fg=red>!' : '') // on CI it is not just for you...
             )
         );
 

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -27,6 +27,11 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
         // always register XmlPublisher
         $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\XmlPublisher';
 
+        // If current server is SauceLabs, autoregister the SauceLabsPublisher
+        if (strpos($config->serverUrl, 'saucelabs.com') !== false) {
+            $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\SauceLabsPublisher';
+        }
+
         // other publishers register only if $config->publishResults is true
         if ($config->publishResults) {
             $publishersToRegister = array_merge($publishersToRegister, $testPublishers);

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -5,6 +5,7 @@ namespace Lmc\Steward\Listener;
 use Lmc\Steward\ConfigProvider;
 use Lmc\Steward\Process\ProcessWrapper;
 use Lmc\Steward\Publisher\AbstractPublisher;
+use Lmc\Steward\Selenium\SeleniumServerAdapter;
 
 /**
  * Listener to log status of test case and at the end of suite publish them using registered publishers.
@@ -28,7 +29,8 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
         $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\XmlPublisher';
 
         // If current server is SauceLabs, autoregister the SauceLabsPublisher
-        if (strpos($config->serverUrl, 'saucelabs.com') !== false) {
+        $seleniumServerAdapter = new SeleniumServerAdapter($config->serverUrl);
+        if ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS) {
             $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\SauceLabsPublisher';
         }
 

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -71,6 +71,7 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
                 $publisher->publishResult(
                     get_class($test),
                     $test->getName(),
+                    $test,
                     $status = AbstractPublisher::TEST_STATUS_STARTED
                 );
             } catch (\Exception $e) {
@@ -95,6 +96,7 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
                 $publisher->publishResult(
                     get_class($test),
                     $test->getName(),
+                    $test,
                     $status = AbstractPublisher::TEST_STATUS_DONE,
                     $result = AbstractPublisher::$testResultsMap[$test->getStatus()],
                     $test->getStatusMessage()

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -73,6 +73,7 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
             [
                 WebDriverCapabilityType::BROWSER_NAME => $config->browserName,
                 WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+                'name' => get_class($test) . '::' . $test->getName(),
             ]
         );
 
@@ -85,7 +86,6 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
 
         $ci = CiDetector::detect();
         if ($ci) {
-            $capabilities->setCapability('name', get_class($test) . '::' . $test->getName());
             $capabilities->setCapability(
                 'build',
                 ConfigProvider::getInstance()->env . '-' . CiDetector::detect()->getBuildNumber()

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -11,6 +11,7 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
 use Facebook\WebDriver\Remote\WebDriverCapabilityType;
 use Facebook\WebDriver\WebDriverPlatform;
 use Lmc\Steward\ConfigProvider;
+use Lmc\Steward\Selenium\SeleniumServerAdapter;
 use Lmc\Steward\Test\AbstractTestCase;
 use Lmc\Steward\WebDriver\NullWebDriver;
 use Lmc\Steward\WebDriver\RemoteWebDriver;
@@ -76,7 +77,7 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
 
         $this->createWebDriver(
             $test,
-            $config->serverUrl . '/wd/hub',
+            $config->serverUrl .  SeleniumServerAdapter::HUB_ENDPOINT,
             $this->setupCustomCapabilities($capabilities, $config->browserName),
             $connectTimeoutMs = 2*60*1000,
             // How long could request to Selenium take (eg. how long could we wait in hub's queue to available node)

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -16,6 +16,7 @@ use Lmc\Steward\Test\AbstractTestCase;
 use Lmc\Steward\WebDriver\NullWebDriver;
 use Lmc\Steward\WebDriver\RemoteWebDriver;
 use Nette\Reflection\AnnotationsParser;
+use OndraM\CiDetector;
 
 /**
  * Listener for initialization and destruction of WebDriver before and after each test.
@@ -80,6 +81,19 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
             foreach ($extraCapabilities as $extraCapabilityName => $extraCapabilityValue) {
                 $capabilities->setCapability($extraCapabilityName, $extraCapabilityValue);
             }
+        }
+
+        $ci = CiDetector::detect();
+        if ($ci) {
+            $capabilities->setCapability('name', get_class($test) . '::' . $test->getName());
+            $capabilities->setCapability(
+                'build',
+                ConfigProvider::getInstance()->env . '-' . CiDetector::detect()->getBuildNumber()
+            );
+            $capabilities->setCapability(
+                'tags',
+                [ConfigProvider::getInstance()->env, $ci->getCiName(), get_class($test)]
+            );
         }
 
         $this->createWebDriver(

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -75,6 +75,13 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
             ]
         );
 
+        if (!empty($config->capability)) {
+            $extraCapabilities = json_decode($config->capability);
+            foreach ($extraCapabilities as $extraCapabilityName => $extraCapabilityValue) {
+                $capabilities->setCapability($extraCapabilityName, $extraCapabilityValue);
+            }
+        }
+
         $this->createWebDriver(
             $test,
             $config->serverUrl .  SeleniumServerAdapter::HUB_ENDPOINT,
@@ -123,11 +130,11 @@ class WebDriverListener extends \PHPUnit_Framework_BaseTestListener
      * Subroutine to encapsulate creation of real WebDriver. Handles some exceptions that may occur etc.
      * The WebDriver instance is stored to $test->wd when created.
      *
-     * @param AbstractTestCase $test
+     * @param string AbstractTestCase $test
      * @param $remoteServerUrl
      * @param DesiredCapabilities $capabilities
-     * @param $connectTimeoutMs
-     * @param $requestTimeoutMs
+     * @param int $connectTimeoutMs
+     * @param int $requestTimeoutMs
      */
     protected function createWebDriver(
         AbstractTestCase $test,

--- a/src/Publisher/AbstractPublisher.php
+++ b/src/Publisher/AbstractPublisher.php
@@ -70,9 +70,17 @@ abstract class AbstractPublisher
      *
      * @param string $testCaseName
      * @param string $testName
+     * @param \PHPUnit_Framework_Test $testInstance
      * @param string $status One of self::$testStatuses
      * @param string $result One of self::$testResults
      * @param string $message
      */
-    abstract public function publishResult($testCaseName, $testName, $status, $result = null, $message = null);
+    abstract public function publishResult(
+        $testCaseName,
+        $testName,
+        \PHPUnit_Framework_Test $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    );
 }

--- a/src/Publisher/SauceLabsPublisher.php
+++ b/src/Publisher/SauceLabsPublisher.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Lmc\Steward\Publisher;
+
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Lmc\Steward\ConfigProvider;
+use Lmc\Steward\Selenium\SeleniumServerAdapter;
+use Lmc\Steward\Test\AbstractTestCaseBase;
+
+/**
+ * Publish test results to SauceLabs API
+ */
+class SauceLabsPublisher extends AbstractPublisher
+{
+    const API_URL = 'https://saucelabs.com/rest/v1';
+
+    public function publishResults(
+        $testCaseName,
+        $status,
+        $result = null,
+        \DateTimeInterface $startDate = null,
+        \DateTimeInterface $endDate = null
+    ) {
+        // we publish only result for each separate test using publishResult()
+    }
+
+    public function publishResult(
+        $testCaseName,
+        $testName,
+        \PHPUnit_Framework_Test $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    ) {
+        if ($status != self::TEST_STATUS_DONE) {
+            return;
+        }
+        if ($result == self::TEST_RESULT_SKIPPED || $result == self::TEST_RESULT_INCOMPLETE) {
+            return;
+        }
+
+        if (!$testInstance instanceof AbstractTestCaseBase || !$testInstance->wd instanceof RemoteWebDriver) {
+            return;
+        }
+
+        if ($result == self::TEST_RESULT_PASSED) {
+            $sauceResult = true;
+        } else {
+            $sauceResult = false;
+        }
+
+        $serverUrl = ConfigProvider::getInstance()->serverUrl;
+        $serverUrlParts = (new SeleniumServerAdapter($serverUrl))->getServerUrlParts();
+
+        $endpointUrl = sprintf(
+            '%s/%s/jobs/%s',
+            self::API_URL,
+            $serverUrlParts['user'],
+            $testInstance->wd->getSessionID()
+        );
+
+        $curl = $this->initCurl(
+            $endpointUrl,
+            $serverUrlParts['user'] . ':' . $serverUrlParts['pass'],
+            ['passed' => $sauceResult]
+        );
+
+        curl_exec($curl);
+
+        if (curl_errno($curl)) {
+            throw new \Exception(
+                sprintf('Error publishing results of test %s to SauceLabs API: %s', $testName, curl_error($curl))
+            );
+        }
+
+        curl_close($curl);
+    }
+
+    /**
+     * @param string $url
+     * @param string $auth
+     * @param mixed $data Data to be sent
+     * @return resource
+     */
+    private function initCurl($url, $auth, $data)
+    {
+        $curl = curl_init($url);
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_setopt($curl, CURLOPT_USERPWD, $auth);
+
+        $postData = json_encode($data);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
+
+        return $curl;
+    }
+}

--- a/src/Publisher/XmlPublisher.php
+++ b/src/Publisher/XmlPublisher.php
@@ -59,15 +59,6 @@ class XmlPublisher extends AbstractPublisher
         }
     }
 
-    /**
-     * Publish testcase result
-     *
-     * @param string $testCaseName
-     * @param string $status
-     * @param string $result
-     * @param \DateTimeInterface $startDate Testcase start datetime
-     * @param \DateTimeInterface $endDate Testcase end datetime
-     */
     public function publishResults(
         $testCaseName,
         $status,
@@ -92,17 +83,14 @@ class XmlPublisher extends AbstractPublisher
         $this->writeAndUnlock($xml);
     }
 
-    /**
-     * Publish results of one single test
-     *
-     * @param string $testCaseName
-     * @param string $testName
-     * @param string $status
-     * @param string $result
-     * @param string $message
-     */
-    public function publishResult($testCaseName, $testName, $status, $result = null, $message = null)
-    {
+    public function publishResult(
+        $testCaseName,
+        $testName,
+        \PHPUnit_Framework_Test $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    ) {
         if (!in_array($status, self::$testStatuses)) {
             throw new \InvalidArgumentException(
                 sprintf('Tests status must be one of "%s", but "%s" given', join(', ', self::$testStatuses), $status)

--- a/src/Selenium/SeleniumServerAdapter.php
+++ b/src/Selenium/SeleniumServerAdapter.php
@@ -10,9 +10,23 @@ class SeleniumServerAdapter
 {
     const HUB_ENDPOINT = '/wd/hub';
     const STATUS_ENDPOINT = '/wd/hub/status';
+    const DEFAULT_PORT = 4444;
+    const DEFAULT_PORT_CLOUD_SERVICE = 80;
 
+    /** @var array */
+    protected $serverUrlParts;
     /** @var string */
     protected $lastError;
+    /** @var bool */
+    protected $cloudService = false;
+
+    /**
+     * @param string $serverUrl
+     */
+    public function __construct($serverUrl)
+    {
+        $this->serverUrlParts = $this->parseServerUrl($serverUrl);
+    }
 
     /**
      * Get description of last error
@@ -24,17 +38,46 @@ class SeleniumServerAdapter
     }
 
     /**
+     * @return array
+     */
+    public function getServerUrlParts()
+    {
+        return $this->serverUrlParts;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServerUrl()
+    {
+        $parts = $this->serverUrlParts;
+
+        $serverUrl = $parts['scheme'] . '://';
+        $serverUrl .= isset($parts['user']) ? $parts['user'] : '';
+        $serverUrl .= isset($parts['pass']) ? ':' . $parts['pass'] : '';
+        $serverUrl .= (isset($parts['user']) || isset($parts['pass'])) ? '@' : '';
+        $serverUrl .= $parts['host'] . ':' . $parts['port'];
+        $serverUrl .= isset($parts['path']) ? $parts['path'] : '';
+        $serverUrl .= isset($parts['query']) ? '?' . $parts['query'] : '';
+
+        return $serverUrl;
+    }
+
+    /**
      * Test if server URL is accessible
      *
-     * @param string $seleniumServerUrl
      * @return bool
      */
-    public function isAccessible($seleniumServerUrl)
+    public function isAccessible()
     {
-        $urlParts = parse_url($seleniumServerUrl);
-
         // Check connection to server is possible
-        $seleniumConnection = @fsockopen($urlParts['host'], $urlParts['port'], $connectionErrorNo, $connectionError, 5);
+        $seleniumConnection = @fsockopen(
+            $this->serverUrlParts['host'],
+            $this->serverUrlParts['port'],
+            $connectionErrorNo,
+            $connectionError,
+            5
+        );
         if (!is_resource($seleniumConnection)) {
             $this->lastError = $connectionError;
             return false;
@@ -47,14 +90,13 @@ class SeleniumServerAdapter
     /**
      * Test if server is really an Selenium server
      *
-     * @param string $seleniumServerUrl
      * @return bool
      */
-    public function isSeleniumServer($seleniumServerUrl)
+    public function isSeleniumServer()
     {
         // Check server properly responds to http requests
         $context = stream_context_create(['http' => ['ignore_errors' => true, 'timeout' => 5]]);
-        $responseData = @file_get_contents($seleniumServerUrl . self::STATUS_ENDPOINT, false, $context);
+        $responseData = @file_get_contents($this->getServerUrl() . self::STATUS_ENDPOINT, false, $context);
 
         if (!$responseData) {
             $this->lastError = 'error reading server response';
@@ -67,5 +109,55 @@ class SeleniumServerAdapter
         }
 
         return true;
+    }
+
+    /**
+     * Is current server cloud service?
+     *
+     * @return bool
+     */
+    public function isCloudService()
+    {
+        return $this->cloudService;
+    }
+
+    /**
+     * @param $seleniumServerUrl
+     * @return array URL parts. Scheme, host and port are always non-empty.
+     */
+    protected function parseServerUrl($seleniumServerUrl)
+    {
+        $urlParts = parse_url($seleniumServerUrl);
+
+        if (!is_array($urlParts)|| empty($urlParts['scheme']) || empty($urlParts['host'])) {
+            throw new \RuntimeException(sprintf('Provided Selenium server URL "%s" is invalid', $seleniumServerUrl));
+        }
+
+        if ($this->detectCloudService($urlParts['host'])) {
+            $this->cloudService = true;
+        }
+
+        if (empty($urlParts['port'])) {
+            if ($this->cloudService) {
+                $urlParts['port'] = self::DEFAULT_PORT_CLOUD_SERVICE;
+            } else {
+                $urlParts['port'] = self::DEFAULT_PORT;
+            }
+        }
+
+        return $urlParts;
+    }
+
+    /**
+     * @param string $host
+     * @return bool
+     */
+    protected function detectCloudService($host)
+    {
+        if (strpos($host, 'saucelabs.com') !== false || strpos($host, 'browserstack.com') !== false) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Selenium/SeleniumServerAdapter.php
+++ b/src/Selenium/SeleniumServerAdapter.php
@@ -8,6 +8,9 @@ namespace Lmc\Steward\Selenium;
  */
 class SeleniumServerAdapter
 {
+    const HUB_ENDPOINT = '/wd/hub';
+    const STATUS_ENDPOINT = '/wd/hub/status';
+
     /** @var string */
     protected $lastError;
 
@@ -51,7 +54,7 @@ class SeleniumServerAdapter
     {
         // Check server properly responds to http requests
         $context = stream_context_create(['http' => ['ignore_errors' => true, 'timeout' => 5]]);
-        $responseData = @file_get_contents($seleniumServerUrl . '/wd/hub/status/', false, $context);
+        $responseData = @file_get_contents($seleniumServerUrl . self::STATUS_ENDPOINT, false, $context);
 
         if (!$responseData) {
             $this->lastError = 'error reading server response';


### PR DESCRIPTION
Few improvements in Steward to simplify support of Selenium cloud services (eg. automatic build number detection, port detection etc.). 

Also automatic publishing of results to SauceLabs API (to make the test results available on SauceLabs Dashboard) was added.

As part of the changes option to pass any capability to the Selenium Server was added  (using `--capability=foo:bar` option of `run` command)
