### PR TITLE
Check one class per file & refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Directory for logs is automatically created if it does not exist. ([#67](https://github.com/lmc-eu/steward/issues/67))
 - Process output printed to console (when using `-vv` or `-vvv`) is now prefixed with class name.
 - BC: Pass instance of current PHPUnit test as third parameter of `publishResult()` method of `AbstractPublisher` descendants.
+- Throw an exception if there are multiple testcase classes defined in one file.
 
 ### Fixed
 - Parsing of latest Selenium server version in `install` command so that even Selenium 3 beta releases are installed ([#76](https://github.com/lmc-eu/steward/pull/76))

--- a/src-tests/Process/Fixtures/InvalidTests/MultipleClassesInFileTest.php
+++ b/src-tests/Process/Fixtures/InvalidTests/MultipleClassesInFileTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Lmc\Steward\Process\Fixtures\InvalidTests;
+
+use Lmc\Steward\Test\AbstractTestCase;
+
+/**
+ * File containing two classes (thus violating PSR-0 and PSR-4).
+ * @codingStandardsIgnoreFile
+ */
+class MultipleClassesInFileTest extends AbstractTestCase
+{
+}
+
+class AnotherClassTest extends AbstractTestCase
+{
+}

--- a/src-tests/Process/Fixtures/InvalidTests/WrongClassTest.php
+++ b/src-tests/Process/Fixtures/InvalidTests/WrongClassTest.php
@@ -6,6 +6,7 @@ use Lmc\Steward\Test\AbstractTestCase;
 
 /**
  * Class with wrong name (differs from name of the file)
+ * @codingStandardsIgnoreFile
  */
 class ReallyWrongClassTest extends AbstractTestCase
 {

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -118,8 +118,8 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
     public function testShouldThrowExceptionIfAddingFileWithNoClass()
     {
         $files = $this->findDummyTests('NoClassTest.php', 'InvalidTests');
-
         $fileName = key(iterator_to_array($files->getIterator()));
+
         $this->setExpectedException(
             \RuntimeException::class,
             'No class found in file "' . $fileName . '"'
@@ -139,6 +139,20 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         );
         $this->creator->createFromFiles($files, [], []);
     }
+
+    public function testShouldThrowExceptionIfMultipleClassesAreDefinedInFile()
+    {
+        $files = $this->findDummyTests('MultipleClassesInFileTest.php', 'InvalidTests');
+        $fileName = key(iterator_to_array($files->getIterator()));
+
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'File "' . $fileName . '" contains definition of 2 classes. However, each class must be defined in its'
+            . ' own separate file.'
+        );
+        $this->creator->createFromFiles($files, [], []);
+    }
+
 
     public function testShouldOnlyAddTestsOfGivenGroups()
     {


### PR DESCRIPTION
As per PSR-0 & PSR-4 there could only be 1 class in file. No other behavior was supported, however, if this rule wasn't followed, no exception nor warning was shown.
