### PR TITLE
Add support of TestingBot cloud service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).
 - Command `clean` to remove old content of logs directory (previous png screenshots, HTML snapshots and JUnit xmls).
 - Option `--capability` to `run` command which allows to simply pass any custom DesiredCapabilities to the WebDriver server.
-- Support for cloud services like [SauceLabs](https://saucelabs.com/) or [BrowserStack](https://www.browserstack.com/) - simply pass remote server URL (including credentials) using `--server-url`.
+- Support for cloud services like [SauceLabs](https://saucelabs.com/), [BrowserStack](https://www.browserstack.com/) or [TestingBot](https://testingbot.com/) - simply pass remote server URL (including credentials) using `--server-url`.
 - If [SauceLabs](https://saucelabs.com/) is used as a remote cloud platform, test results are automatically published to SauceLabs API when test is done.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).
 - Command `clean` to remove old content of logs directory (previous png screenshots, HTML snapshots and JUnit xmls).
 - Option `--capability` to `run` command which allows to simply pass any custom DesiredCapabilities to the WebDriver server.
-- Support for cloud services like [SauceLabs](https://saucelabs.com/), [BrowserStack](https://www.browserstack.com/) or [TestingBot](https://testingbot.com/) - simply pass remote server URL (including credentials) using `--server-url`.
-- If [SauceLabs](https://saucelabs.com/) is used as a remote cloud platform, test results are automatically published to SauceLabs API when test is done.
+- Support for cloud services like [Sauce Labs](https://saucelabs.com/), [BrowserStack](https://www.browserstack.com/) or [TestingBot](https://testingbot.com/) - simply pass remote server URL (including credentials) using `--server-url`.
+- If [Sauce Labs](https://saucelabs.com/) or [TestingBot](https://testingbot.com/) is used as a remote cloud platform, test results are automatically published to their API.
 
 ### Changed
 - Content of directory with logs is cleaned before `run` command starts by default. This could be suppressed using `--no-clean` option of the `run` command. ([#63](https://github.com/lmc-eu/steward/issues/63))

--- a/src-tests/ConfigHelper.php
+++ b/src-tests/ConfigHelper.php
@@ -28,7 +28,7 @@ class ConfigHelper
             'BROWSER_NAME' => 'firefox',
             'ENV' => 'testing',
             'SERVER_URL' => 'http://server.tld:port',
-            'CAPABILITY' => '',
+            'CAPABILITY' => '', // intentionally empty, used by ConfigProviderTest::testShouldDetectEmptyConfigOption
             'PUBLISH_RESULTS' => 0,
             'FIXTURES_DIR' => __DIR__,
             'LOGS_DIR' => __DIR__,

--- a/src-tests/ConfigProviderTest.php
+++ b/src-tests/ConfigProviderTest.php
@@ -36,6 +36,17 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://server.tld:port', ConfigProvider::getInstance()->serverUrl);
     }
 
+    public function testShouldDetectEmptyConfigOption()
+    {
+        ConfigHelper::setEnvironmentVariables($this->environmentVariables);
+
+        $nonEmptyValue = empty(ConfigProvider::getInstance()->serverUrl);
+        $emptyValue = empty(ConfigProvider::getInstance()->capability);
+
+        $this->assertFalse($nonEmptyValue);
+        $this->assertTrue($emptyValue);
+    }
+
     /**
      * @expectedException \DomainException
      * @expectedExceptionMessage Configuration option "notExisting" was not defined

--- a/src-tests/Publisher/AbstractCloudPublisherTestCase.php
+++ b/src-tests/Publisher/AbstractCloudPublisherTestCase.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Lmc\Steward\Publisher;
+
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Lmc\Steward\Test\AbstractTestCaseBase;
+use Lmc\Steward\WebDriver\NullWebDriver;
+use phpmock\phpunit\PHPMock;
+
+abstract class AbstractCloudPublisherTestCase extends \PHPUnit_Framework_TestCase
+{
+    use PHPMock;
+
+    /** @var AbstractCloudPublisher */
+    protected $publisher;
+    /** @var \PHPUnit_Framework_MockObject_MockObject|AbstractTestCaseBase */
+    protected $testInstanceMock;
+
+    public function setUp()
+    {
+        $this->testInstanceMock = $this->getMockBuilder(AbstractTestCaseBase::class)
+            ->getMock();
+    }
+
+    public function testShouldDoNothingWhenPublishingTestcaseResults()
+    {
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResults('testCaseName', AbstractPublisher::TEST_STATUS_DONE);
+    }
+
+    public function testShouldDoNothingIfTestStatusIsNotDone()
+    {
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_STARTED
+        );
+    }
+
+    public function testShouldDoNothingIfTestResultIsSkippedOrIncomplete()
+    {
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_SKIPPED
+        );
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_INCOMPLETE
+        );
+    }
+
+    public function testShouldDoNothingIfTestContainsInstanceOfNullWebdriver()
+    {
+        $this->testInstanceMock->wd = new NullWebDriver();
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->never());
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE
+        );
+    }
+
+    public function testShouldThrowExceptionIfPublishToApiFailed()
+    {
+        $this->testInstanceMock->wd = $this->getMockBuilder(RemoteWebDriver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_init');
+        $curlInitMock->expects($this->any());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
+        $curlInitMock->expects($this->any());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_exec');
+        $curlInitMock->expects($this->once());
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_errno');
+        $curlInitMock->expects($this->once())
+            ->willReturn(333);
+
+        $curlInitMock = $this->getFunctionMock(__NAMESPACE__, 'curl_error');
+        $curlInitMock->expects($this->once())
+            ->willReturn('omg wtf');
+
+        $this->setExpectedExceptionRegExp(
+            \Exception::class,
+            '/Error publishing results of test testBar to API "https:\/\/.*": omg wtf/'
+        );
+
+        $this->publisher->publishResult(
+            'testCaseFoo',
+            'testBar',
+            $this->testInstanceMock,
+            AbstractPublisher::TEST_STATUS_DONE,
+            AbstractPublisher::TEST_RESULT_PASSED
+        );
+    }
+}

--- a/src-tests/Publisher/SauceLabsPublisherTest.php
+++ b/src-tests/Publisher/SauceLabsPublisherTest.php
@@ -28,7 +28,7 @@ class SauceLabsPublisherTest extends AbstractCloudPublisherTestCase
      * @param string $testResult
      * @param string $expectedData
      */
-    public function testShouldPublishTestResult($testResult, $expectedData)
+    public function testShouldPublishTestResult($testResult, $message, $expectedData)
     {
         $this->testInstanceMock->wd = $this->getMockBuilder(RemoteWebDriver::class)
             ->disableOriginalConstructor()
@@ -57,7 +57,8 @@ class SauceLabsPublisherTest extends AbstractCloudPublisherTestCase
             'testBar',
             $this->testInstanceMock,
             AbstractPublisher::TEST_STATUS_DONE,
-            $testResult
+            $testResult,
+            $message
         );
     }
 
@@ -67,9 +68,14 @@ class SauceLabsPublisherTest extends AbstractCloudPublisherTestCase
     public function resultProvider()
     {
         return [
-            'Passed test' => [AbstractPublisher::TEST_RESULT_PASSED, '{"passed":true}'],
-            'Failed test' => [AbstractPublisher::TEST_RESULT_FAILED, '{"passed":false}'],
-            'Broken test' => [AbstractPublisher::TEST_RESULT_BROKEN, '{"passed":false}'],
+            'Passed test' => [AbstractPublisher::TEST_RESULT_PASSED, null, '{"passed":true}'],
+            'Failed test' => [AbstractPublisher::TEST_RESULT_FAILED, null, '{"passed":false}'],
+            'Failed test with message' => [
+                AbstractPublisher::TEST_RESULT_FAILED,
+                'Error occurred',
+                '{"passed":false,"custom-data":{"message":"Error occurred"}}',
+            ],
+            'Broken test' => [AbstractPublisher::TEST_RESULT_BROKEN, null, '{"passed":false}'],
         ];
     }
 }

--- a/src-tests/Selenium/Fixtures/response-testingbot.json
+++ b/src-tests/Selenium/Fixtures/response-testingbot.json
@@ -1,0 +1,13 @@
+{
+  "status": 0,
+  "sessionId": null,
+  "value": {
+    "build": {
+      "version": "TestingBot"
+    },
+    "details": {
+      "status": "available",
+      "details": "TestingBot Selenium Grid is fully operational"
+    }
+  }
+}

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -59,8 +59,12 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
             'local URL without port should use 4444' => ['http://localhost', 'http://localhost:4444'],
             'cloud service URL with port should keep it' =>
                 ['http://foo:bar@ondemand.saucelabs.com:1337', 'http://foo:bar@ondemand.saucelabs.com:1337'],
-            'cloud service URL without port should use 80' =>
+            'Sauce Labs cloud service without port should use 80' =>
                 ['http://foo:bar@ondemand.saucelabs.com', 'http://foo:bar@ondemand.saucelabs.com:80'],
+            'BrowserStack cloud service without port should use 80' =>
+                ['http://foo:bar@hub-cloud.browserstack.com', 'http://foo:bar@hub-cloud.browserstack.com:80'],
+            'TestingBot cloud service without port should use 80' =>
+                ['http://foo:bar@hub.testingbot.com', 'http://foo:bar@hub.testingbot.com:80'],
             'non-cloud URL without port should use 4444' => ['http://foo.com', 'http://foo.com:4444'],
             'username and host should get deault port' => ['http://user@foo', 'http://user@foo:4444'],
             'all parts' =>
@@ -220,12 +224,14 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $responseSauceLabs = file_get_contents(__DIR__ . '/Fixtures/response-saucelabs.json');
         $responseBrowserStack = file_get_contents(__DIR__ . '/Fixtures/response-browserstack.json');
+        $responseTestingBot = file_get_contents(__DIR__ . '/Fixtures/response-testingbot.json');
         $responseStandalone = file_get_contents(__DIR__ . '/Fixtures/response-standalone.json');
         $responseLocalGrid = file_get_contents(__DIR__ . '/Fixtures/response-grid.json');
 
         return [
-            'SauceLabs' => [$responseSauceLabs, SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS],
+            'Sauce Labs' => [$responseSauceLabs, SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS],
             'BrowserStack' => [$responseBrowserStack, SeleniumServerAdapter::CLOUD_SERVICE_BROWSERSTACK],
+            'TestingBot' => [$responseTestingBot, SeleniumServerAdapter::CLOUD_SERVICE_TESTINGBOT],
             'non-cloud local standalone server' => [$responseStandalone, ''],
             'non-cloud local grid' => [$responseLocalGrid, ''],
         ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -40,6 +40,17 @@ class ConfigProvider
         throw new \DomainException(sprintf('Configuration option "%s" was not defined', $name));
     }
 
+    public function __isset($name)
+    {
+        $value = $this->getInstance()->getConfig()->getItem($name, null);
+
+        if (empty($value)) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Add custom configuration options that should be added to the default ones. Can be set only before first call of
      * getConfig(), as the values must be given to the Config object upon initialization.

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -28,10 +28,12 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
         // always register XmlPublisher
         $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\XmlPublisher';
 
-        // If current server is SauceLabs, autoregister the SauceLabsPublisher
+        // If current server is SauceLabs/TestingBot, autoregister its publisher
         $seleniumServerAdapter = new SeleniumServerAdapter($config->serverUrl);
         if ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS) {
             $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\SauceLabsPublisher';
+        } elseif ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_TESTINGBOT) {
+            $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\TestingBotPublisher';
         }
 
         // other publishers register only if $config->publishResults is true

--- a/src/Publisher/AbstractCloudPublisher.php
+++ b/src/Publisher/AbstractCloudPublisher.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Lmc\Steward\Publisher;
+
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Lmc\Steward\Test\AbstractTestCaseBase;
+
+/**
+ * Abstract publisher for cloud services with HTTP API to store test results
+ */
+abstract class AbstractCloudPublisher extends AbstractPublisher
+{
+    /** @var string Content type of the request */
+    const CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
+    public function publishResults(
+        $testCaseName,
+        $status,
+        $result = null,
+        \DateTimeInterface $startDate = null,
+        \DateTimeInterface $endDate = null
+    ) {
+        // we publish only result for each separate test using publishResult()
+    }
+
+    public function publishResult(
+        $testCaseName,
+        $testName,
+        \PHPUnit_Framework_Test $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    ) {
+        if ($status != self::TEST_STATUS_DONE) {
+            return;
+        }
+        if ($result == self::TEST_RESULT_SKIPPED || $result == self::TEST_RESULT_INCOMPLETE) {
+            return;
+        }
+
+        if (!$testInstance instanceof AbstractTestCaseBase || !$testInstance->wd instanceof RemoteWebDriver) {
+            return;
+        }
+
+        $url = $this->getEndpointUrl($testInstance);
+        $curl = $this->initCurl($url, $this->getAuth());
+
+        curl_setopt(
+            $curl,
+            CURLOPT_POSTFIELDS,
+            $this->getData($testCaseName, $testName, $testInstance, $status, $result, $message)
+        );
+
+        curl_exec($curl);
+
+        if (curl_errno($curl)) {
+            throw new \Exception(
+                sprintf('Error publishing results of test %s to API "%s": %s', $testName, $url, curl_error($curl))
+            );
+        }
+
+        curl_close($curl);
+    }
+
+    /**
+     * @param string $url
+     * @param string $auth
+     * @return resource
+     */
+    protected function initCurl($url, $auth)
+    {
+        $curl = curl_init($url);
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, ['Content-Type: ' . static::CONTENT_TYPE]);
+        curl_setopt($curl, CURLOPT_USERPWD, $auth);
+
+        return $curl;
+    }
+
+    /**
+     * Get URL of the API endpoint where to put result data
+     *
+     * @param AbstractTestCaseBase $testInstance
+     * @return string
+     */
+    abstract protected function getEndpointUrl(AbstractTestCaseBase $testInstance);
+
+    /**
+     * Get authentication string
+     *
+     * @return string
+     */
+    abstract protected function getAuth();
+
+    /**
+     * Get data to be send to the API
+     *
+     * @param string $testCaseName
+     * @param string $testName
+     * @param AbstractTestCaseBase $testInstance
+     * @param string $status
+     * @param string $result
+     * @param string $message
+     * @return mixed
+     */
+    abstract protected function getData(
+        $testCaseName,
+        $testName,
+        AbstractTestCaseBase $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    );
+}

--- a/src/Publisher/SauceLabsPublisher.php
+++ b/src/Publisher/SauceLabsPublisher.php
@@ -40,6 +40,10 @@ class SauceLabsPublisher extends AbstractCloudPublisher
     ) {
         $data = ['passed' => ($result == self::TEST_RESULT_PASSED)];
 
+        if (!empty($message)) {
+            $data['custom-data'] = ['message' => $message];
+        }
+
         return json_encode($data);
     }
 }

--- a/src/Publisher/TestingBotPublisher.php
+++ b/src/Publisher/TestingBotPublisher.php
@@ -7,19 +7,15 @@ use Lmc\Steward\Selenium\SeleniumServerAdapter;
 use Lmc\Steward\Test\AbstractTestCaseBase;
 
 /**
- * Publish test results to SauceLabs API
+ * Publish test results to TestingBot API
  */
-class SauceLabsPublisher extends AbstractCloudPublisher
+class TestingBotPublisher extends AbstractCloudPublisher
 {
-    const API_URL = 'https://saucelabs.com/rest/v1';
-    const CONTENT_TYPE = 'application/json';
+    const API_URL = 'https://api.testingbot.com/v1';
 
     protected function getEndpointUrl(AbstractTestCaseBase $testInstance)
     {
-        $serverUrl = ConfigProvider::getInstance()->serverUrl;
-        $serverUrlParts = (new SeleniumServerAdapter($serverUrl))->getServerUrlParts();
-
-        return sprintf('%s/%s/jobs/%s', self::API_URL, $serverUrlParts['user'], $testInstance->wd->getSessionID());
+        return sprintf('%s/tests/%s', self::API_URL, $testInstance->wd->getSessionID());
     }
 
     protected function getAuth()
@@ -38,8 +34,18 @@ class SauceLabsPublisher extends AbstractCloudPublisher
         $result = null,
         $message = null
     ) {
-        $data = ['passed' => ($result == self::TEST_RESULT_PASSED)];
+        if ($result == self::TEST_RESULT_PASSED) {
+            $resultToPublish = 1;
+        } else {
+            $resultToPublish = 0;
+        }
 
-        return json_encode($data);
+        $data = ['test[success]' => $resultToPublish];
+
+        if (!empty($message)) {
+            $data['test[status_message]'] = $message;
+        }
+
+        return http_build_query($data, null, '&');
     }
 }


### PR DESCRIPTION
Added full-featured support of https://testingbot.com cloud service, including publishing test results to [TestingBot API](https://testingbot.com/support/api#updatetest) (this is very similar to Sauce Labs, so most of the changes are actually refactoring of the SauceLabs specific code to make it reusable).
