### PR TITLE
Remove --publish-results option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Removed
 - BC: Aliases for old non-namespaced [php-webdriver](https://github.com/facebook/php-webdriver) which were deprecated in Steward 1.2.
 - BC: `run-tests` alias of `run` command.
+- BC: Option `--publish-results` of run command. The default publishers and custom publishers defined in phpunit.xml will be always registered.
 
 ### Added
 - Command `results` to show test results summary from the command line (CLI equivalent to viewing `results.xml` in a browser).

--- a/src-tests/ConfigHelper.php
+++ b/src-tests/ConfigHelper.php
@@ -27,7 +27,7 @@ class ConfigHelper
         return [
             'BROWSER_NAME' => 'firefox',
             'ENV' => 'testing',
-            'SERVER_URL' => 'http://server.tld:port',
+            'SERVER_URL' => 'http://server.tld:4444',
             'CAPABILITY' => '', // intentionally empty, used by ConfigProviderTest::testShouldDetectEmptyConfigOption
             'FIXTURES_DIR' => __DIR__,
             'LOGS_DIR' => __DIR__,

--- a/src-tests/ConfigHelper.php
+++ b/src-tests/ConfigHelper.php
@@ -29,7 +29,6 @@ class ConfigHelper
             'ENV' => 'testing',
             'SERVER_URL' => 'http://server.tld:port',
             'CAPABILITY' => '', // intentionally empty, used by ConfigProviderTest::testShouldDetectEmptyConfigOption
-            'PUBLISH_RESULTS' => 0,
             'FIXTURES_DIR' => __DIR__,
             'LOGS_DIR' => __DIR__,
             'DEBUG' => 0,

--- a/src-tests/ConfigProviderTest.php
+++ b/src-tests/ConfigProviderTest.php
@@ -22,9 +22,9 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
         $config = ConfigProvider::getInstance()->getConfig();
 
         // Property access
-        $this->assertEquals('http://server.tld:port', $config->serverUrl);
+        $this->assertEquals('http://server.tld:4444', $config->serverUrl);
         // getItem() access
-        $this->assertEquals('http://server.tld:port', $config->getItem('serverUrl'));
+        $this->assertEquals('http://server.tld:4444', $config->getItem('serverUrl'));
         // all items retrieval
         $this->assertInternalType('array', $config->getItems());
     }
@@ -33,7 +33,7 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
     {
         ConfigHelper::setEnvironmentVariables($this->environmentVariables);
 
-        $this->assertEquals('http://server.tld:port', ConfigProvider::getInstance()->serverUrl);
+        $this->assertEquals('http://server.tld:4444', ConfigProvider::getInstance()->serverUrl);
     }
 
     public function testShouldDetectEmptyConfigOption()

--- a/src-tests/Listener/Fixtures/DummyPublisher.php
+++ b/src-tests/Listener/Fixtures/DummyPublisher.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lmc\Steward\Listener\Fixtures;
+
+use Lmc\Steward\Publisher\AbstractPublisher;
+
+class DummyPublisher extends AbstractPublisher
+{
+    public function publishResults(
+        $testCaseName,
+        $status,
+        $result = null,
+        \DateTimeInterface $startDate = null,
+        \DateTimeInterface $endDate = null
+    ) {
+    }
+
+    public function publishResult(
+        $testCaseName,
+        $testName,
+        \PHPUnit_Framework_Test $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    ) {
+    }
+}

--- a/src-tests/Listener/TestStatusListenerTest.php
+++ b/src-tests/Listener/TestStatusListenerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Lmc\Steward\Listener;
+
+use Lmc\Steward\ConfigHelper;
+use Lmc\Steward\Listener\Fixtures\DummyPublisher;
+use Lmc\Steward\Publisher\SauceLabsPublisher;
+use Lmc\Steward\Publisher\TestingBotPublisher;
+use Lmc\Steward\Selenium\SeleniumServerAdapter;
+
+class TestStatusListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var SeleniumServerAdapter|\PHPUnit_Framework_MockObject_MockObject */
+    protected $seleniumAdapterMock;
+
+    public function setUp()
+    {
+        $this->seleniumAdapterMock = $this->getMockBuilder(SeleniumServerAdapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configValues = ConfigHelper::getDummyConfig();
+        $configValues['DEBUG'] = 1;
+        ConfigHelper::setEnvironmentVariables($configValues);
+        ConfigHelper::unsetConfigInstance();
+    }
+
+    public function testShouldRegisterXmlPublisherByDefault()
+    {
+        new TestStatusListener([], $this->seleniumAdapterMock);
+
+        $this->expectOutputRegex('/Registering test results publisher "Lmc\x5cSteward\x5cPublisher\x5cXmlPublisher"$/');
+    }
+
+    /**
+     * @dataProvider cloudServiceProvider
+     * @param string $detectedCloudService
+     * @param array $customPublishers
+     * @param array $expectedExtraPublishers
+     */
+    public function testShouldRegisterExtraPublishers(
+        $detectedCloudService,
+        array $customPublishers,
+        array $expectedExtraPublishers
+    ) {
+        $this->seleniumAdapterMock->expects($this->any())
+            ->method('getCloudService')
+            ->willReturn($detectedCloudService);
+
+        new TestStatusListener($customPublishers, $this->seleniumAdapterMock);
+
+        $this->expectOutputRegex('/Registering test results publisher "Lmc\x5cSteward\x5cPublisher\x5cXmlPublisher"/');
+        $output = $this->getActualOutput();
+        $this->assertSame(
+            count($expectedExtraPublishers) + 1, // +1 for XmlPublisher, which is expected always
+            mb_substr_count($output, 'Registering test results publisher'),
+            'Mismatching number of registered publishers'
+        );
+
+        foreach ($expectedExtraPublishers as $expectedExtraPublisher) {
+            $this->assertContains(
+                'Registering test results publisher "' . $expectedExtraPublisher . '"',
+                $output
+            );
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    public function cloudServiceProvider()
+    {
+        return [
+            'No cloud service, no custom publisher' => ['', [], []],
+            'Sauce Labs service' => [SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS, [], [SauceLabsPublisher::class]],
+            'TestingBot service' => [SeleniumServerAdapter::CLOUD_SERVICE_TESTINGBOT, [], [TestingBotPublisher::class]],
+            'No cloud service, custom Publisher' => ['', [DummyPublisher::class], [DummyPublisher::class]],
+            'Cloud service and custom Publisher' => [
+                SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS,
+                [DummyPublisher::class],
+                [DummyPublisher::class, SauceLabsPublisher::class],
+            ],
+        ];
+    }
+
+    public function testShouldThrowAnExceptionIfRegisteringNotExistingClassAsPublisher()
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'Cannot add new test publisher, class "Foo\NotExistingClass" not found'
+        );
+
+        $this->expectOutputRegex('/.*/'); // workaround to force PHpUnit to swallow output
+
+        new TestStatusListener(['Foo\NotExistingClass'], $this->seleniumAdapterMock);
+    }
+
+    public function testShouldThrowAnExceptionIfRegisteringImproperPublisher()
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            'Cannot add new test publisher, class "stdClass" must be an instance of "AbstractPublisher"'
+        );
+
+        $this->expectOutputRegex('/.*/'); // workaround to force PHpUnit to swallow output
+
+        new TestStatusListener(['stdClass'], $this->seleniumAdapterMock);
+    }
+}

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -108,7 +108,6 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
             'BROWSER_NAME' => 'firefox',
             'ENV' => 'staging',
             'SERVER_URL' => $definition->getOption(RunCommand::OPTION_SERVER_URL)->getDefault(),
-            'PUBLISH_RESULTS' => 0,
             'FIXTURES_DIR' => $definition->getOption(RunCommand::OPTION_FIXTURES_DIR)->getDefault(),
             'LOGS_DIR' => $definition->getOption(RunCommand::OPTION_LOGS_DIR)->getDefault(),
         ];
@@ -262,7 +261,6 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
             . ' --' . RunCommand::OPTION_SERVER_URL . '=http://foo.bar:1337'
             . ' --' . RunCommand::OPTION_FIXTURES_DIR . '=custom-fixtures-dir/'
             . ' --' . RunCommand::OPTION_LOGS_DIR . '=custom-logs-dir/'
-            . ' --' . RunCommand::OPTION_PUBLISH_RESULTS
             . ' --' . RunCommand::OPTION_CAPABILITY . '=webdriver.log.file:/foo/bar.log'
             . ' --' . RunCommand::OPTION_CAPABILITY . '="capability.in.quotes:/foo/ba r.log"'
             . ' --' . RunCommand::OPTION_CAPABILITY . '="platform:OS X 10.8"'
@@ -290,7 +288,6 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
                 'BROWSER_NAME' => 'chrome',
                 'ENV' => 'trolling',
                 'SERVER_URL' => 'http://foo.bar:1337',
-                'PUBLISH_RESULTS' => '1',
                 'FIXTURES_DIR' => 'custom-fixtures-dir/',
                 'LOGS_DIR' => 'custom-logs-dir/',
                 'CAPABILITY' => '{"webdriver.log.file":"\/foo\/bar.log","capability.in.quotes":"\/foo\/ba r.log",'

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -14,7 +14,6 @@ use FlorianWolters\Component\Util\Singleton\SingletonTrait;
  * @property-read string env
  * @property-read string serverUrl
  * @property-read string capability
- * @property-read string publishResults
  * @property-read string fixturesDir
  * @property-read string logsDir
  * @property-read string debug
@@ -105,7 +104,6 @@ class ConfigProvider
             'ENV',
             'SERVER_URL',
             'CAPABILITY',
-            'PUBLISH_RESULTS',
             'FIXTURES_DIR',
             'LOGS_DIR',
             'DEBUG',

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -51,7 +51,6 @@ class RunCommand extends Command
     const OPTION_GROUP = 'group';
     const OPTION_EXCLUDE_GROUP = 'exclude-group';
     const OPTION_FILTER = 'filter';
-    const OPTION_PUBLISH_RESULTS = 'publish-results';
     const OPTION_NO_EXIT = 'no-exit';
     const OPTION_IGNORE_DELAYS = 'ignore-delays';
 
@@ -150,12 +149,6 @@ class RunCommand extends Command
                 'Run only testcases/tests with name matching this filter'
             )
             ->addOption(
-                self::OPTION_PUBLISH_RESULTS,
-                null,
-                InputOption::VALUE_NONE,
-                'Publish test results to test storage'
-            )
-            ->addOption(
                 self::OPTION_NO_EXIT,
                 null,
                 InputOption::VALUE_NONE,
@@ -240,9 +233,6 @@ class RunCommand extends Command
             );
             $output->writeln(
                 sprintf('Path to logs: %s', $input->getOption(self::OPTION_LOGS_DIR))
-            );
-            $output->writeln(
-                sprintf('Publish results: %s', ($input->getOption(self::OPTION_PUBLISH_RESULTS)) ? 'yes' : 'no')
             );
             $output->writeln(
                 sprintf('Ignore delays: %s', ($input->getOption(self::OPTION_IGNORE_DELAYS)) ? 'yes' : 'no')

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -20,16 +20,19 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
 
     /**
      * @param AbstractPublisher[] $customTestPublishers Array of fully qualified names of AbstractPublisher classes
+     * @param SeleniumServerAdapter $seleniumServerAdapter Inject SeleniumServerAdapter. Used only for tests.
      */
-    public function __construct(array $customTestPublishers)
+    public function __construct(array $customTestPublishers, SeleniumServerAdapter $seleniumServerAdapter = null)
     {
         $config = ConfigProvider::getInstance();
+        if (is_null($seleniumServerAdapter)) {
+            $seleniumServerAdapter = new SeleniumServerAdapter($config->serverUrl);
+        }
 
         // always register XmlPublisher
         $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\XmlPublisher';
 
         // If current server is SauceLabs/TestingBot, autoregister its publisher
-        $seleniumServerAdapter = new SeleniumServerAdapter($config->serverUrl);
         if ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS) {
             $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\SauceLabsPublisher';
         } elseif ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_TESTINGBOT) {

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -19,9 +19,9 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
     protected $startDate;
 
     /**
-     * @param array $testPublishers Array of fully qualified names of AbstractPublisher classes
+     * @param AbstractPublisher[] $customTestPublishers Array of fully qualified names of AbstractPublisher classes
      */
-    public function __construct(array $testPublishers)
+    public function __construct(array $customTestPublishers)
     {
         $config = ConfigProvider::getInstance();
 
@@ -36,10 +36,8 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
             $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\TestingBotPublisher';
         }
 
-        // other publishers register only if $config->publishResults is true
-        if ($config->publishResults) {
-            $publishersToRegister = array_merge($publishersToRegister, $testPublishers);
-        }
+        // register custom publishers
+        $publishersToRegister = array_merge($publishersToRegister, $customTestPublishers);
 
         foreach ($publishersToRegister as $publisherClass) {
             if (!class_exists($publisherClass)) {

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -5,6 +5,9 @@ namespace Lmc\Steward\Listener;
 use Lmc\Steward\ConfigProvider;
 use Lmc\Steward\Process\ProcessWrapper;
 use Lmc\Steward\Publisher\AbstractPublisher;
+use Lmc\Steward\Publisher\SauceLabsPublisher;
+use Lmc\Steward\Publisher\TestingBotPublisher;
+use Lmc\Steward\Publisher\XmlPublisher;
 use Lmc\Steward\Selenium\SeleniumServerAdapter;
 
 /**
@@ -30,13 +33,13 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
         }
 
         // always register XmlPublisher
-        $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\XmlPublisher';
+        $publishersToRegister[] = XmlPublisher::class;
 
         // If current server is SauceLabs/TestingBot, autoregister its publisher
         if ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS) {
-            $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\SauceLabsPublisher';
+            $publishersToRegister[] = SauceLabsPublisher::class;
         } elseif ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_TESTINGBOT) {
-            $publishersToRegister[] = 'Lmc\\Steward\\Publisher\\TestingBotPublisher';
+            $publishersToRegister[] = TestingBotPublisher::class;
         }
 
         // register custom publishers

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -184,7 +184,6 @@ class ProcessSetCreator
             ->setEnv('ENV', mb_strtolower($this->input->getArgument(RunCommand::ARGUMENT_ENVIRONMENT)))
             ->setEnv('CAPABILITY', $this->encodeCapabilties($this->input->getOption(RunCommand::OPTION_CAPABILITY)))
             ->setEnv('SERVER_URL', $this->input->getOption(RunCommand::OPTION_SERVER_URL))
-            ->setEnv('PUBLISH_RESULTS', $this->input->getOption(RunCommand::OPTION_PUBLISH_RESULTS) ? '1' : '0')
             ->setEnv('FIXTURES_DIR', $this->input->getOption(RunCommand::OPTION_FIXTURES_DIR))
             ->setEnv('LOGS_DIR', $this->input->getOption(RunCommand::OPTION_LOGS_DIR))
             ->setEnv('DEBUG', $this->output->isDebug() ? '1' : '0')


### PR DESCRIPTION
The default publishers but also all custom publishers defined in phpunit.xml will now be registered always, no matter the option.
