### PR TITLE
 Drop PHP 5.5 support for the 2.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7
   - 7.1
@@ -10,7 +9,7 @@ matrix:
   allow_failures:
     - php: 7.1
   include:
-    - php: 5.5
+    - php: 5.6
       env: dependencies="--prefer-lowest --prefer-stable"
     - php: 7
       env: dependencies="--prefer-lowest --prefer-stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2.0.0 - unreleased
 ### Removed
+- Support for PHP 5.5, minimal required version of PHP is now 5.6. Also the 5.5 version is [no longer supported](https://secure.php.net/supported-versions.php) by the upstream since July.
 - BC: Aliases for old non-namespaced [php-webdriver](https://github.com/facebook/php-webdriver) which were deprecated in Steward 1.2.
 - BC: `run-tests` alias of `run` command.
 - BC: Option `--publish-results` of run command. The default publishers and custom publishers defined in phpunit.xml will be always registered.

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "caseyamcl/configula": "~2.3",
         "doctrine/inflector": "~1.0",
         "beberlei/assert": "^2.4",
-        "ondram/ci-detector": "^0.3.0"
+        "ondram/ci-detector": "^1.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.4.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^5.6 || ~7.0",
         "ext-zip": "*",
         "ext-curl": "*",
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.5",
         "symfony/console": "~3.0",
         "symfony/process": "^3.0.4",
         "symfony/finder": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     },
     "require": {
-        "php": "^5.5.5 || ~7.0",
+        "php": "^5.6 || ~7.0",
         "ext-zip": "*",
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.8.6 || ~5.0",
+        "phpunit/phpunit": "^5.0",
         "symfony/console": "~3.0",
         "symfony/process": "^3.0.4",
         "symfony/finder": "~3.0",

--- a/src-tests/Component/AbstractComponentTest.php
+++ b/src-tests/Component/AbstractComponentTest.php
@@ -58,12 +58,13 @@ class AbstractComponentTest extends \PHPUnit_Framework_TestCase
         $this->component->debug('Foo %s', 'bar');
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error
-     * @expectedExceptionMessage Call to undefined method Lmc\Steward\Component\AbstractComponent::notExisting()
-     */
     public function testShouldFailIfNotExistingMethodIsCalled()
     {
+        $this->expectException(\PHPUnit_Framework_Error::class);
+        $this->expectExceptionMessage(
+            'Call to undefined method Lmc\Steward\Component\AbstractComponent::notExisting()'
+        );
+
         $this->component->notExisting('Bazbar');
     }
 }

--- a/src-tests/Component/LegacyTest.php
+++ b/src-tests/Component/LegacyTest.php
@@ -29,22 +29,17 @@ class LegacyTest extends \PHPUnit_Framework_TestCase
         ConfigHelper::unsetConfigInstance();
     }
 
-    /**
-     * @expectedException Lmc\Steward\Component\LegacyException
-     * @expectedExceptionMessage Cannot read legacy file
-     */
     public function testShouldThrowExceptionIfLegacyFileNotFound()
     {
         $legacy = new Legacy($this->testCase);
         $this->expectOutputRegex('/.*New legacy instantiated.*/');
 
+        $this->expectException(LegacyException::class);
+        $this->expectExceptionMessage('Cannot read legacy file');
+
         $legacy->loadWithName('not-existing');
     }
 
-    /**
-     * @expectedException Lmc\Steward\Component\LegacyException
-     * @expectedExceptionMessage Cannot parse legacy from file
-     */
     public function testShouldFailIfNotUnserializableFileFound()
     {
         $fn = sys_get_temp_dir() . '/wrong.legacy';
@@ -53,6 +48,9 @@ class LegacyTest extends \PHPUnit_Framework_TestCase
         $legacy = new Legacy($this->testCase);
         $legacy->setFileDir(sys_get_temp_dir());
         $this->expectOutputRegex('/.*New legacy instantiated.*/');
+
+        $this->expectException(LegacyException::class);
+        $this->expectExceptionMessage('Cannot parse legacy from file');
 
         $legacy->loadWithName('wrong');
     }
@@ -92,16 +90,16 @@ class LegacyTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($sampleData, $output);
     }
 
-    /**
-     * @expectedException Lmc\Steward\Component\LegacyException
-     * @expectedExceptionMessage Cannot save legacy to file /notexisting/baz.legacy
-     */
     public function testShouldFailIfSavingToNotExistingDirectory()
     {
         $legacy = new Legacy($this->testCase);
         $legacy->setFileDir('/notexisting');
 
         $this->expectOutputRegex('/.*Saving data as legacy "baz" to file "\/notexisting\/baz\.legacy".*/');
+
+        $this->expectException(LegacyException::class);
+        $this->expectExceptionMessage('Cannot save legacy to file /notexisting/baz.legacy');
+
         $legacy->saveWithName([], 'baz');
     }
 
@@ -137,10 +135,6 @@ class LegacyTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputRegex('/^((?!foobar string).)*$/s'); // Output should not contain the string
     }
 
-    /**
-     * @expectedException Lmc\Steward\Component\LegacyException
-     * @expectedExceptionMessage Cannot generate legacy name from class without 'Phase' followed by number in name
-     */
     public function testShouldFailIfTryingToAutomaticallySaveLegacyIfTestDoesntHavePhaseInItsName()
     {
         $testCasePhase1 = $this->getMockBuilder(AbstractTestCase::class)
@@ -150,6 +144,11 @@ class LegacyTest extends \PHPUnit_Framework_TestCase
 
         $legacy = new Legacy($testCasePhase1);
         $legacy->setFileDir(sys_get_temp_dir());
+
+        $this->expectException(LegacyException::class);
+        $this->expectExceptionMessage(
+            'Cannot generate legacy name from class without \'Phase\' followed by number in name'
+        );
 
         $legacy->save('data');
     }

--- a/src-tests/ConfigProviderTest.php
+++ b/src-tests/ConfigProviderTest.php
@@ -47,13 +47,12 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($emptyValue);
     }
 
-    /**
-     * @expectedException \DomainException
-     * @expectedExceptionMessage Configuration option "notExisting" was not defined
-     */
     public function testShouldThrowExceptionWhenAccessingNotExistingConfigOptionThroughConfigProvider()
     {
         ConfigHelper::setEnvironmentVariables($this->environmentVariables);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Configuration option "notExisting" was not defined');
 
         ConfigProvider::getInstance()->notExisting;
     }
@@ -69,16 +68,16 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($firstInstance, $secondInstance);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage SERVER_URL environment variable must be defined
-     */
     public function testShouldFailIfRequiredOptionIsNotDefined()
     {
         ConfigHelper::setEnvironmentVariables($this->environmentVariables);
         putenv('SERVER_URL'); // unset value
 
         $provider = ConfigProvider::getInstance();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SERVER_URL environment variable must be defined');
+
         $provider->getConfig();
     }
 
@@ -97,16 +96,17 @@ class ConfigProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('new', $config->customOption);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Custom configuration options can be set only before the Config object was instantiated
-     */
     public function testShouldFailIfSettingCustomConfigurationOptionsAfterFirstInstantiation()
     {
         ConfigHelper::setEnvironmentVariables($this->environmentVariables);
         $provider = ConfigProvider::getInstance();
         // Create Config instance
         $provider->getConfig();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Custom configuration options can be set only before the Config object was instantiated'
+        );
 
         // This should fail, as the Config instance was already created
         $provider->setCustomConfigurationOptions(['CUSTOM_OPTION']);

--- a/src-tests/Console/Command/CleanCommandTest.php
+++ b/src-tests/Console/Command/CleanCommandTest.php
@@ -30,8 +30,8 @@ class CleanCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldShowErrorIfLogsDirectoryIsNotDefaultAndCannotBeFound()
     {
-        $this->setExpectedException(
-            \RuntimeException::class,
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
             'Cannot clean logs directory "/custom/not/accessible/path", make sure it is accessible.'
         );
 

--- a/src-tests/Console/Command/ResultsCommandTest.php
+++ b/src-tests/Console/Command/ResultsCommandTest.php
@@ -29,7 +29,8 @@ class ResultsCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldShowErrorIfResultsFileCannotBeFound()
     {
-        $this->setExpectedException(\RuntimeException::class, 'Cannot read results file "/not/accessible.xml"');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot read results file "/not/accessible.xml"');
 
         $this->tester->execute(
             [

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -34,34 +34,31 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
         $this->tester = new CommandTester($this->command);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "environment, browser").
-     */
     public function testShouldFailWithoutArguments()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "environment, browser").');
+
         $this->tester->execute(
             ['command' => $this->command->getName()]
         );
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "browser").
-     */
     public function testShouldFailWithoutBrowserSpecified()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "browser").');
+
         $this->tester->execute(
             ['command' => $this->command->getName(), 'environment' => 'staging']
         );
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "environment").
-     */
     public function testShouldFailWithoutEnvironmentSpecified()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "environment").');
+
         $this->tester->execute(
             ['command' => $this->command->getName(), 'browser' => 'firefox']
         );
@@ -82,7 +79,8 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
             $errorBeginning,
             $directoryOption
         );
-        $this->setExpectedException('\RuntimeException', $expectedError);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($expectedError);
 
         $this->tester->execute(
             [
@@ -136,12 +134,13 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldThrowExceptionIfUnsupportedBrowserSelected($browserName, $shouldThrowException)
     {
-        if ($shouldThrowException) {
-            $this->setExpectedException('\RuntimeException', 'Browser "' . $browserName . '" is not supported');
-        }
-
         $seleniumAdapterMock = $this->getSeleniumAdapterMock();
         $this->command->setSeleniumAdapter($seleniumAdapterMock);
+
+        if ($shouldThrowException) {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Browser "' . $browserName . '" is not supported');
+        }
 
         $this->tester->execute(
             ['command' => $this->command->getName(), 'environment' => 'prod', 'browser' => $browserName],

--- a/src-tests/Console/EventListener/XdebugListenerTest.php
+++ b/src-tests/Console/EventListener/XdebugListenerTest.php
@@ -114,10 +114,6 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Extension Xdebug is not loaded or installed
-     */
     public function testShouldFailWhenXdebugExtensionIsNotLoaded()
     {
         $this->mockXdebugExtension($isExtensionLoaded = false, $isRemoteEnabled = false);
@@ -128,6 +124,9 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
             new StringInput('env firefox --xdebug'),
             new BufferedOutput()
         );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Extension Xdebug is not loaded or installed');
 
         $this->listener->onCommandRunTestsInit($event);
     }
@@ -143,8 +142,8 @@ class XdebugListenerTest extends \PHPUnit_Framework_TestCase
             new BufferedOutput()
         );
 
-        $this->setExpectedException(
-            \RuntimeException::class,
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
             'The xdebug.remote_enable directive must be set to true to enable remote debugging.'
         );
 

--- a/src-tests/Console/Style/StewardStyleTest.php
+++ b/src-tests/Console/Style/StewardStyleTest.php
@@ -163,7 +163,8 @@ HTXT;
      */
     public function testShouldThrowExceptionOnNotImplementedMethods($method, array $args)
     {
-        $this->setExpectedException(\Exception::class, 'Method not implemented');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Method not implemented');
 
         call_user_func_array([$this->style, $method], $args);
     }

--- a/src-tests/Listener/TestStatusListenerTest.php
+++ b/src-tests/Listener/TestStatusListenerTest.php
@@ -85,24 +85,22 @@ class TestStatusListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldThrowAnExceptionIfRegisteringNotExistingClassAsPublisher()
     {
-        $this->setExpectedException(
-            \RuntimeException::class,
-            'Cannot add new test publisher, class "Foo\NotExistingClass" not found'
-        );
+        $this->expectOutputRegex('/.*/'); // workaround to force PHPUnit to swallow output
 
-        $this->expectOutputRegex('/.*/'); // workaround to force PHpUnit to swallow output
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot add new test publisher, class "Foo\NotExistingClass" not found');
 
         new TestStatusListener(['Foo\NotExistingClass'], $this->seleniumAdapterMock);
     }
 
     public function testShouldThrowAnExceptionIfRegisteringImproperPublisher()
     {
-        $this->setExpectedException(
-            \RuntimeException::class,
+        $this->expectOutputRegex('/.*/'); // workaround to force PHPUnit to swallow output
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
             'Cannot add new test publisher, class "stdClass" must be an instance of "AbstractPublisher"'
         );
-
-        $this->expectOutputRegex('/.*/'); // workaround to force PHpUnit to swallow output
 
         new TestStatusListener(['stdClass'], $this->seleniumAdapterMock);
     }

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -119,10 +119,9 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $files = $this->findDummyTests('NoClassTest.php', 'InvalidTests');
         $fileName = key(iterator_to_array($files->getIterator()));
 
-        $this->setExpectedException(
-            \RuntimeException::class,
-            'No class found in file "' . $fileName . '"'
-        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No class found in file "' . $fileName . '"');
+
         $this->creator->createFromFiles($files, [], []);
     }
 
@@ -131,11 +130,12 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $files = $this->findDummyTests('WrongClassTest.php', 'InvalidTests');
 
         $fileName = key(iterator_to_array($files->getIterator()));
-        $this->setExpectedException(
-            \RuntimeException::class,
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
             'Error loading class "Lmc\Steward\Process\Fixtures\InvalidTests\ReallyWrongClassTest" from file "'
             . $fileName . '". Make sure the class name and namespace matches the file path.'
         );
+
         $this->creator->createFromFiles($files, [], []);
     }
 
@@ -144,8 +144,8 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $files = $this->findDummyTests('MultipleClassesInFileTest.php', 'InvalidTests');
         $fileName = key(iterator_to_array($files->getIterator()));
 
-        $this->setExpectedException(
-            \RuntimeException::class,
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
             'File "' . $fileName . '" contains definition of 2 classes. However, each class must be defined in its'
             . ' own separate file.'
         );
@@ -232,11 +232,12 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
     {
         $files = $this->findDummyTests('InvalidDelayTest.php', 'InvalidTests');
 
-        $this->setExpectedException(
-            \InvalidArgumentException::class,
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
             'Testcase "Lmc\Steward\Process\Fixtures\InvalidTests\InvalidDelayTest" has defined delay 5 minutes, '
             . 'but doesn\'t have defined the testcase to run after'
         );
+
         $this->creator->createFromFiles($files, [], []);
     }
 
@@ -316,10 +317,9 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
 
         $files = $this->findDummyTests('DummyTest.php');
 
-        $this->setExpectedException(
-            RuntimeException::class,
-            'Capability must be given in format "capabilityName:value" but "foo" was given'
-        );
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Capability must be given in format "capabilityName:value" but "foo" was given');
+
         $this->creator->createFromFiles($files, [], []);
     }
 

--- a/src-tests/Process/ProcessSetTest.php
+++ b/src-tests/Process/ProcessSetTest.php
@@ -30,13 +30,13 @@ class ProcessSetTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $this->set);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Testcase with name "Foo\Bar" was already added
-     */
     public function testShouldFailWhenAddingTestWithNonUniqueName()
     {
         $this->set->add(new ProcessWrapper(new Process(''), 'Foo\Bar'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Testcase with name "Foo\Bar" was already added');
+
         $this->set->add(new ProcessWrapper(new Process(''), 'Foo\Bar'));
     }
 
@@ -242,17 +242,13 @@ class ProcessSetTest extends \PHPUnit_Framework_TestCase
 
         $this->set->add($process);
 
-        $this->setExpectedException(
-            \InvalidArgumentException::class,
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
             'Testcase "Foo" has @delayAfter dependency on "NotExisting", but this testcase was not defined.'
         );
         $this->set->buildTree();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot build tree graph from tests dependencies.
-     */
     public function testShouldFailBuildingTreeIfCycleDetected()
     {
         /*
@@ -268,6 +264,10 @@ class ProcessSetTest extends \PHPUnit_Framework_TestCase
 
         $this->set->add($processA);
         $this->set->add($processB);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot build tree graph from tests dependencies.');
+
         $this->set->buildTree();
     }
 
@@ -417,10 +417,9 @@ class ProcessSetTest extends \PHPUnit_Framework_TestCase
         $this->set->add($processA);
         $this->set->add($processB);
 
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Cannot get dependency tree - the tree was not yet build using buildTree()'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot get dependency tree - the tree was not yet build using buildTree()');
+
         $this->set->failDependants('A');
     }
 }

--- a/src-tests/Process/ProcessWrapperTest.php
+++ b/src-tests/Process/ProcessWrapperTest.php
@@ -55,7 +55,8 @@ class ProcessWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $wrapper = new ProcessWrapper(new Process(''), 'Foo');
 
-        $this->setExpectedException(InvalidArgumentException::class, $expectedExceptionMessage);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
 
         $wrapper->setDelay('Bar', $delay);
     }
@@ -81,13 +82,12 @@ class ProcessWrapperTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Testcase "Foo" should run after "Bar", but no delay was defined
-     */
     public function testShouldFailIfDependencyWasDefinedButWithoutDelay()
     {
         $wrapper = new ProcessWrapper(new Process(''), 'Foo');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Testcase "Foo" should run after "Bar", but no delay was defined');
 
         $wrapper->setDelay('Bar', null);
     }
@@ -149,10 +149,11 @@ class ProcessWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $wrapper = new ProcessWrapper(new Process(''), 'Foo');
 
-        $this->setExpectedException(
-            InvalidArgumentException::class,
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
             'Value "WrongStatus" is not an element of the valid values: prepared, queued, done'
         );
+
         $wrapper->setStatus('WrongStatus');
     }
 

--- a/src-tests/Publisher/AbstractCloudPublisherTestCase.php
+++ b/src-tests/Publisher/AbstractCloudPublisherTestCase.php
@@ -103,8 +103,8 @@ abstract class AbstractCloudPublisherTestCase extends \PHPUnit_Framework_TestCas
         $curlInitMock->expects($this->once())
             ->willReturn('omg wtf');
 
-        $this->setExpectedExceptionRegExp(
-            \Exception::class,
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp(
             '/Error publishing results of test testBar to API "https:\/\/.*": omg wtf/'
         );
 

--- a/src-tests/Publisher/XmlPublisherTest.php
+++ b/src-tests/Publisher/XmlPublisherTest.php
@@ -71,21 +71,22 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         $this->assertFileNotExists($fn);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Tests status must be one of "started, done", but "unknownStatus" given
-     */
     public function testShouldNotAllowToPublishUnknownTestStatus()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tests status must be one of "started, done", but "unknownStatus" given');
+
         $this->publisher->publishResult('testCaseName', 'testName', $this->testInstanceMock, 'unknownStatus');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Tests result must be null or one of "passed, failed, broken, skipped, incomplete"
-     */
     public function testShouldNotAllowToPublishUnknownTestResult()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Tests result must be null or one of "passed, failed, broken, skipped, incomplete", '
+            . 'but "unknownResult" given'
+        );
+
         $this->publisher->publishResult(
             'testCaseName',
             'testName',
@@ -206,10 +207,6 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($xml->testcase['end']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Directory "/notexisting" does not exist or is not writeable.
-     */
     public function testShouldFailIfGivenDirectoryDoesNotExists()
     {
         $configValues = ConfigHelper::getDummyConfig();
@@ -218,6 +215,10 @@ class XmlPublisherTest extends \PHPUnit_Framework_TestCase
         ConfigHelper::unsetConfigInstance();
 
         $publisher = new XmlPublisher();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Directory "/notexisting" does not exist or is not writeable.');
+
         $publisher->publishResult('testCaseNameFoo', 'testNameBar', $this->testInstanceMock, 'started');
     }
 

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -80,10 +80,8 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldThrowExceptionIfInvalidServerUrlIsGiven($serverUrl)
     {
-        $this->setExpectedException(
-            \RuntimeException::class,
-            'Provided Selenium server URL "' . $serverUrl . '" is invalid'
-        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Provided Selenium server URL "' . $serverUrl . '" is invalid');
 
         new SeleniumServerAdapter($serverUrl);
     }
@@ -193,8 +191,8 @@ class SeleniumServerAdapterTest extends \PHPUnit_Framework_TestCase
             ->with($this->serverUrl . '/wd/hub/status')
             ->willReturn('THIS IS NOT JSON');
 
-        $this->setExpectedExceptionRegExp(
-            \RuntimeException::class,
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp(
             '/^Unable to connect to remote server: error parsing server JSON response \(.+\)$/'
         );
 

--- a/src-tests/WebDriver/NullWebDriverTest.php
+++ b/src-tests/WebDriver/NullWebDriverTest.php
@@ -20,11 +20,12 @@ class NullWebDriverTest extends \PHPUnit_Framework_TestCase
      * @param $methodName
      * @param $params
      * @dataProvider methodNameProvider
-     * @expectedException \Exception
-     * @expectedExceptionMessage You cannot interact with NullWebDriver.
      */
     public function testShouldThrowExceptionWhenInteractingWithInstance($methodName, $params)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You cannot interact with NullWebDriver.');
+
         call_user_func_array([$this->webdriver, $methodName], $params);
     }
 

--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -9,9 +9,9 @@ use Lmc\Steward\Test\SyntaxSugarTrait;
 /**
  * AbstractComponent used as parent of all components to add some default functionality and interface .
  *
- * @method void log(string $message, $arguments = null)
- * @method void warn(string $message, $arguments = null)
- * @method void debug(string $message, $arguments = null)
+ * @method void log(string $format, ...$args)
+ * @method void warn(string $format, ...$args)
+ * @method void debug(string $format, ...$args)
  */
 abstract class AbstractComponent
 {

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -22,7 +22,7 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
     protected $startDate;
 
     /**
-     * @param AbstractPublisher[] $customTestPublishers Array of fully qualified names of AbstractPublisher classes
+     * @param string[] $customTestPublishers Array of fully qualified names of AbstractPublisher classes
      * @param SeleniumServerAdapter $seleniumServerAdapter Inject SeleniumServerAdapter. Used only for tests.
      */
     public function __construct(array $customTestPublishers, SeleniumServerAdapter $seleniumServerAdapter = null)
@@ -33,7 +33,7 @@ class TestStatusListener extends \PHPUnit_Framework_BaseTestListener
         }
 
         // always register XmlPublisher
-        $publishersToRegister[] = XmlPublisher::class;
+        $publishersToRegister = [XmlPublisher::class];
 
         // If current server is SauceLabs/TestingBot, autoregister its publisher
         if ($seleniumServerAdapter->getCloudService() == SeleniumServerAdapter::CLOUD_SERVICE_SAUCELABS) {

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -65,41 +65,40 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
      * @param mixed $args
      * @see log
      */
-    public function appendTestLog($format, $args = null)
+    public function appendTestLog($format, ...$args)
     {
-        $output = $this->formatOutput(func_get_args());
+        $output = $this->formatOutput($format, $args);
         $this->appendedTestLog .= $output;
     }
 
-    public function log($format, $args = null)
+    public function log($format, ...$args)
     {
-        echo $this->formatOutput(func_get_args());
+        echo $this->formatOutput($format, $args);
     }
 
-    public function warn($format, $args = null)
+    public function warn($format, ...$args)
     {
-        echo $this->formatOutput(func_get_args(), 'WARN');
+        echo $this->formatOutput($format, $args, 'WARN');
     }
 
-    public function debug($format, $args = null)
+    public function debug($format, ...$args)
     {
         if (ConfigProvider::getInstance()->debug) {
-            echo $this->formatOutput(func_get_args(), 'DEBUG');
+            echo $this->formatOutput($format, $args, 'DEBUG');
         }
     }
 
     /**
      * Format output
+     * @param string $format
      * @param array $args Array of arguments passed to original sprintf()-like function
      * @param string $type Specific log severity type (WARN, DEBUG) prefixed to output
      * @return string Formatted output
      */
-    protected function formatOutput(array $args, $type = '')
+    protected function formatOutput($format, array $args, $type = '')
     {
-        $format = array_shift($args);
-
         // If first item of arguments contains another array use it as arguments
-        if (!empty($args) && is_array($args[0])) {
+        if (is_array($args[0])) {
             $args = $args[0];
         }
 

--- a/src/Test/AbstractTestCaseBase.php
+++ b/src/Test/AbstractTestCaseBase.php
@@ -16,21 +16,21 @@ abstract class AbstractTestCaseBase extends \PHPUnit_Framework_TestCase
     /**
      * Log to output
      * @param string $format The format string. May use "%" placeholders, in a same way as sprintf()
-     * @param mixed $args,... OPTIONAL Variable number of parameters inserted into $format string
+     * @param mixed ...$args Variable number of parameters inserted into $format string
      */
-    abstract public function log($format, $args = null);
+    abstract public function log($format, ...$args);
 
     /**
      * Log warning to output. Unlike log(), it will be prefixed with "WARN: " and colored.
      * @param string $format The format string. May use "%" placeholders, in a same way as sprintf()
-     * @param mixed $args,... OPTIONAL Variable number of parameters inserted into $format string
+     * @param mixed ...$args Variable number of parameters inserted into $format string
      */
-    abstract public function warn($format, $args = null);
+    abstract public function warn($format, ...$args);
 
     /**
      * Log to output, but only if debug mode is enabled.
      * @param string $format The format string. May use "%" placeholders, in a same way as sprintf()
-     * @param mixed $args,... OPTIONAL Variable number of parameters inserted into $format string
+     * @param mixed ...$args Variable number of parameters inserted into $format string
      */
-    abstract public function debug($format, $args = null);
+    abstract public function debug($format, ...$args);
 }


### PR DESCRIPTION
PHP 5.5 is discontinued and some out dependencies already require PHP 5.6+ (namely PHPUnit 5), so its getting hard to maintain the PHP 5.5 support.
