### PR TITLE
Non-string capabilities passed as an option do not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released in the latest tagged version.
+### Fixed
+- Values passed using `--capability` option may not work as expected for different data types than strings.
 
 ## 2.0.0 - 2016-10-30
 ### Removed

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -258,13 +258,19 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
     public function testShouldPropagateCustomOptionsIntoProcess()
     {
         $this->input = new StringInput(
-            'trolling chrome'
+            'staging chrome'
             . ' --' . RunCommand::OPTION_SERVER_URL . '=http://foo.bar:1337'
             . ' --' . RunCommand::OPTION_FIXTURES_DIR . '=custom-fixtures-dir/'
             . ' --' . RunCommand::OPTION_LOGS_DIR . '=custom-logs-dir/'
             . ' --' . RunCommand::OPTION_CAPABILITY . '=webdriver.log.file:/foo/bar.log'
             . ' --' . RunCommand::OPTION_CAPABILITY . '="capability.in.quotes:/foo/ba r.log"'
             . ' --' . RunCommand::OPTION_CAPABILITY . '="platform:OS X 10.8"'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=stringValue:thisIsString'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=someNumber:1337'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=zeroValue:0'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=floatValue:1.337'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=trueValue:true'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=falseValue:false'
         );
 
         $this->input->bind($this->command->getDefinition());
@@ -287,12 +293,21 @@ class ProcessSetCreatorTest extends \PHPUnit_Framework_TestCase
         $this->assertArraySubset(
             [
                 'BROWSER_NAME' => 'chrome',
-                'ENV' => 'trolling',
+                'ENV' => 'staging',
                 'SERVER_URL' => 'http://foo.bar:1337',
                 'FIXTURES_DIR' => 'custom-fixtures-dir/',
                 'LOGS_DIR' => 'custom-logs-dir/',
-                'CAPABILITY' => '{"webdriver.log.file":"\/foo\/bar.log","capability.in.quotes":"\/foo\/ba r.log",'
-                    . '"platform":"OS X 10.8"}',
+                'CAPABILITY' => '{'
+                    . '"webdriver.log.file":"\/foo\/bar.log",'
+                    . '"capability.in.quotes":"\/foo\/ba r.log",'
+                    . '"platform":"OS X 10.8",'
+                    . '"stringValue":"thisIsString",'
+                    . '"someNumber":1337,'
+                    . '"zeroValue":0,'
+                    . '"floatValue":1.337,'
+                    . '"trueValue":true,'
+                    . '"falseValue":false'
+                    . '}',
             ],
             $processEnv
         );


### PR DESCRIPTION
Values passed using `--capability` option may not work as expected for different data types than strings. E.g. when using `--capability=marionette:false`, the "false" is passed as an string, what makes Selenium server unhappy and ignore the value. Ale `0` value was improperly treated as invalid.

We now attempt to recognize most used JSON data types and cast the original string value to the most appropriate data type.