### PR TITLE
TestUtils deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Deprecate default instantiation of TestUtils in TestCase - `$this->utils` will be removed in next major release. Do your own instantiation when needed.
 - Deprecate `TestUtils::setSelect2Value()` method. Use directly the new `Select2` component.
 - Deprecate `TestUtils::getFixturePath()` method. Use `Facebook\WebDriver\Remote\FileDetector` instead.
+- Deprecate `TestUtils::sleep()` method. Use `AbstractTestCase::sleep()` method instead.
+
 
 ## 2.0.1 - 2016-12-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 ### Changed
 - Deprecate default instantiation of TestUtils in TestCase - `$this->utils` will be removed in next major release. Do your own instantiation when needed.
+- Deprecate `TestUtils::setSelect2Value()` method. Use directly the new `Select2` component.
 
 ## 2.0.1 - 2016-12-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Deprecate default instantiation of TestUtils in TestCase - `$this->utils` will be removed in next major release. Do your own instantiation when needed.
 - Deprecate `TestUtils::setSelect2Value()` method. Use directly the new `Select2` component.
+- Deprecate `TestUtils::getFixturePath()` method. Use `Facebook\WebDriver\Remote\FileDetector` instead.
 
 ## 2.0.1 - 2016-12-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-- Nothing yet - everything is released in the latest tagged version.
+### Changed
+- Deprecate default instantiation of TestUtils in TestCase - `$this->utils` will be removed in next major release. Do your own instantiation when needed.
 
 ## 2.0.1 - 2016-12-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## Unreleased
 ### Changed
-- Deprecate default instantiation of TestUtils in TestCase - `$this->utils` will be removed in next major release. Do your own instantiation when needed.
-- Deprecate `TestUtils::setSelect2Value()` method. Use directly the new `Select2` component.
-- Deprecate `TestUtils::getFixturePath()` method. Use `Facebook\WebDriver\Remote\FileDetector` instead.
-- Deprecate `TestUtils::sleep()` method. Use `AbstractTestCase::sleep()` method instead.
-
+- Deprecate `TestUtils`. The class will be removed in next major release. This includes:
+    - Deprecate default instantiation of TestUtils in TestCase - `$this->utils` property of TestCase.
+    - Deprecate `TestUtils::setSelect2Value()` method. Use directly the new `Select2` component.
+    - Deprecate `TestUtils::getFixturePath()` method. Use `Facebook\WebDriver\Remote\FileDetector` instead.
+    - Deprecate `TestUtils::sleep()` method. Use `AbstractTestCase::sleep()` method instead.
 
 ## 2.0.1 - 2016-12-01
 ### Fixed

--- a/src/Component/Select2.php
+++ b/src/Component/Select2.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Lmc\Steward\Component;
+
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverExpectedCondition;
+
+/**
+ * Manipulate the Select2 UI component
+ * @see https://select2.github.io/
+ */
+class Select2 extends AbstractComponent
+{
+    /**
+     * Set value of Select2 element
+     * @param string $originalId ID of original select/input element
+     * @param string $value Value to be selected
+     * @param bool $multiSelect OPTIONAL Is the select multiselect?
+     * @todo Support multiple values for multiselects
+     */
+    public function setSelect2Value($originalId, $value, $multiSelect = false)
+    {
+        $select2selector = '#s2id_' . $originalId;
+
+        // Wait for select2 to appear
+        $select2link = $this->tc->wd->wait()->until(
+            WebDriverExpectedCondition::presenceOfElementLocated(
+                WebDriverBy::cssSelector($select2selector . ' ' . ($multiSelect ? 'input' : 'a'))
+            )
+        );
+
+        // Click on element to open dropdown - to copy users behavior
+        $select2link->click();
+
+        $this->log('Sending keys to select2: %s', $value);
+
+        // Insert searched term into s2 generated input
+        $this->tc->wd
+            ->findElement(WebDriverBy::cssSelector($multiSelect ? $select2selector . ' input' : '#select2-drop input'))
+            ->sendKeys($value);
+
+        // Wait until result are rendered (or maybe loaded with ajax)
+        $firstResult = $this->tc->wd->wait()->until(
+            WebDriverExpectedCondition::presenceOfElementLocated(
+                WebDriverBy::cssSelector('.select2-drop .select2-result.select2-highlighted')
+            )
+        );
+
+        $this->log('Dropdown detected, selecting the first result: %s', $firstResult->getText());
+
+        // Select first item in results
+        $firstResult->click();
+    }
+}

--- a/src/Component/TestUtils.php
+++ b/src/Component/TestUtils.php
@@ -17,39 +17,11 @@ class TestUtils extends AbstractComponent
      * @param string $value Value to be selected
      * @param bool $multiSelect OPTIONAL Is the select multiselect?
      * @todo Support multiple values for multiselects
+     * @deprecated Use Select2 component
      */
     public function setSelect2Value($originalId, $value, $multiSelect = false)
     {
-        $select2selector = '#s2id_' . $originalId;
-
-        // Wait for select2 to appear
-        $select2link = $this->tc->wd->wait()->until(
-            WebDriverExpectedCondition::presenceOfElementLocated(
-                WebDriverBy::cssSelector($select2selector . ' ' . ($multiSelect ? 'input' : 'a'))
-            )
-        );
-
-        // Click on element to open dropdown - to copy users behavior
-        $select2link->click();
-
-        $this->log('Sending keys to select2: %s', $value);
-
-        // Insert searched term into s2 generated input
-        $this->tc->wd
-            ->findElement(WebDriverBy::cssSelector($multiSelect ? $select2selector . ' input' : '#select2-drop input'))
-            ->sendKeys($value);
-
-        // Wait until result are rendered (or maybe loaded with ajax)
-        $firstResult = $this->tc->wd->wait()->until(
-            WebDriverExpectedCondition::presenceOfElementLocated(
-                WebDriverBy::cssSelector('.select2-drop .select2-result.select2-highlighted')
-            )
-        );
-
-        $this->log('Dropdown detected, selecting the first result: %s', $firstResult->getText());
-
-        // Select first item in results
-        $firstResult->click();
+        (new Select2($this->tc))->setSelect2Value($originalId, $value, $multiSelect);
     }
 
     /**

--- a/src/Component/TestUtils.php
+++ b/src/Component/TestUtils.php
@@ -29,6 +29,7 @@ class TestUtils extends AbstractComponent
      *
      * @param string $fixture Fixture identifier (relative path to fixture from directory with tests)
      * @return string Path to fixture
+     * @deprecated Use FileDetector instead
      */
     public function getFixturePath($fixture)
     {

--- a/src/Component/TestUtils.php
+++ b/src/Component/TestUtils.php
@@ -2,9 +2,8 @@
 
 namespace Lmc\Steward\Component;
 
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverExpectedCondition;
 use Lmc\Steward\ConfigProvider;
+use Lmc\Steward\Test\AbstractTestCase;
 
 /**
  * Common test utils and syntax sugar for tests.
@@ -58,12 +57,10 @@ class TestUtils extends AbstractComponent
      * Unlike sleep(), also the float values are supported.
      * ALWAYS TRY TO USE WAIT() INSTEAD!
      * @param float $seconds
+     * @deprecated Use directly AbstractTestCase::sleep() method
      */
     public static function sleep($seconds)
     {
-        $fullSecond = (int) floor($seconds);
-        $microseconds = fmod($seconds, 1) * 1000000000;
-
-        time_nanosleep($fullSecond, $microseconds);
+        AbstractTestCase::sleep($seconds);
     }
 }

--- a/src/Component/TestUtils.php
+++ b/src/Component/TestUtils.php
@@ -8,7 +8,6 @@ use Lmc\Steward\ConfigProvider;
 
 /**
  * Common test utils and syntax sugar for tests.
- * Should be accessible in all tests.
  */
 class TestUtils extends AbstractComponent
 {

--- a/src/Component/TestUtils.php
+++ b/src/Component/TestUtils.php
@@ -7,6 +7,7 @@ use Lmc\Steward\Test\AbstractTestCase;
 
 /**
  * Common test utils and syntax sugar for tests.
+ * @deprecated
  */
 class TestUtils extends AbstractComponent
 {

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -92,6 +92,20 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
     }
 
     /**
+     * Sleep for given amount of seconds.
+     * Unlike sleep(), also the float values are supported.
+     * ALWAYS TRY TO USE WAIT() INSTEAD!
+     * @param float $seconds
+     */
+    public static function sleep($seconds)
+    {
+        $fullSecond = (int) floor($seconds);
+        $microseconds = fmod($seconds, 1) * 1000000000;
+
+        time_nanosleep($fullSecond, $microseconds);
+    }
+
+    /**
      * Format output
      * @param string $format
      * @param array $args Array of arguments passed to original sprintf()-like function

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -21,7 +21,10 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
     /** @var int Height of browser window */
     public static $browserHeight = 1024;
 
-    /** @var TestUtils Common test utils, instantiated on setUp. */
+    /**
+     * @var TestUtils Common test utils, instantiated on setUp.
+     * @deprecated Do custom instantiation of the Utils if needed. This will be removed in next major release.
+     */
     public $utils;
 
     /** @var string Log appended to output of this test */


### PR DESCRIPTION
TestUtils is kind of antipattern and is just more pain than gain. Its method could (and should) be separated to follow single responsibility principle. Also once it is removed, we can merge AbstractTestCaseBase to AbstractTestCase.