### PR TITLE
Store in results file the executor node of each test (if available)

### DIFF
--- a/src-tests/Selenium/Fixtures/testsession-found.json
+++ b/src-tests/Selenium/Fixtures/testsession-found.json
@@ -1,0 +1,8 @@
+{
+  "msg": "slot found !",
+  "success": true,
+  "session": "4f1bebc2-667e-4b99-b16a-ff36221a20b3",
+  "internalKey": "cb7d4a67-dca8-4588-a8fa-241c5171999c",
+  "inactivityTime": 15277,
+  "proxyId": "http://10.1.255.241:5555"
+}

--- a/src-tests/Selenium/Fixtures/testsession-invalid-response.txt
+++ b/src-tests/Selenium/Fixtures/testsession-invalid-response.txt
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>Error 403 Forbidden for Proxy</title>
+</head>
+<body>
+<h2>HTTP ERROR: 403</h2><pre>Forbidden for Proxy</pre>
+<p>RequestURI=/grid/api/testsession</p>
+<p><i><small><a href="http://jetty.mortbay.org">Powered by Jetty://</a></small></i></p>
+</body>
+</html>

--- a/src-tests/Selenium/Fixtures/testsession-not-found.json
+++ b/src-tests/Selenium/Fixtures/testsession-not-found.json
@@ -1,0 +1,4 @@
+{
+  "success": false,
+  "msg": "Cannot find test slot running session 4f1bebc2-667e-4b99-b16a-ff36221a20b3 in the registry."
+}


### PR DESCRIPTION
As suggested in #94 , we will attempt to save name of the executor of each test into the results.xml file. This will later allow us to generate the timeline for #94 to optimize the tests parallelization.