### PR TITLE
Add possibility to specify capability option value as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Added
+- Capabilities passed using `--capability` CLI option could now force to be specified as an string (by encapsulating into additional quotes).
+
 ### Changed
 - Capabilities are now resolved using `CapabilitiesResolver` class.
 - Require PHPUnit ^5.7

--- a/src-tests/Process/KeyValueCapabilityOptionsParserTest.php
+++ b/src-tests/Process/KeyValueCapabilityOptionsParserTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Lmc\Steward\Process;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+/**
+ * @covers Lmc\Steward\Process\KeyValueCapabilityOptionsParser
+ */
+class KeyValueCapabilityOptionsParserTest extends TestCase
+{
+    /**
+     * @dataProvider provideCapabilities
+     * @param array $capabilityOption
+     * @param array $expectedCapabilities
+     */
+    public function testShouldPropagateCapabilities(array $capabilityOption, array $expectedCapabilities)
+    {
+        $parser = new KeyValueCapabilityOptionsParser();
+
+        $parsedCapabilities = $parser->parse($capabilityOption);
+
+        $this->assertSame($expectedCapabilities, $parsedCapabilities);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideCapabilities()
+    {
+        return [
+            'string value' => [['stringValue:thisIsString'], ['stringValue' => 'thisIsString']],
+            'value with special chars' => [
+                ['webdriver.log.file:/foo/bar.log'],
+                ['webdriver.log.file' => '/foo/bar.log'],
+            ],
+            'capability value with spaces' => [['platform:OS X 10.8'], ['platform' => 'OS X 10.8']],
+            'double enquoted string value should have the quotes removed' => [
+                ['stringValue:"thisIsString"'],
+                ['stringValue' => 'thisIsString'],
+            ],
+            'single enquoted string value should have the quotes removed' => [
+                ["stringValue:'thisIsString'"],
+                ['stringValue' => 'thisIsString'],
+            ],
+            'double enquoted number should be cast to string' => [['version:"47"'], ['version' => '47']],
+            'single enquoted number should be cast to string' => [["version:'47'"], ['version' => '47']],
+            'double enquoted float number should be cast to string' => [
+                ['version:"14.14393"'],
+                ['version' => '14.14393'],
+            ],
+            'single enquoted float number should be cast to string' => [
+                ["version:'14.14393'"],
+                ['version' => '14.14393'],
+            ],
+            'double enquoted bool should be cast to string' => [['foo:"true"'], ['foo' => 'true']],
+            'single enquoted bool should be cast to string' => [["foo:'true'"], ['foo' => 'true']],
+            'wrongly quoted value should be cast to string but with quotations intact' => [
+                ['foo:"bar\\\''],
+                ['foo' => "\"bar\\'"],
+            ],
+            'integer value' => [['someNumber:1337'], ['someNumber' => 1337]],
+            'zero number value' => [['zeroValue:0'], ['zeroValue' => 0]],
+            'float value' => [['floatValue:1.337'], ['floatValue' => 1.337]],
+            'boolean true value' => [['trueValue:true'], ['trueValue' => true]],
+            'boolean false value' => [['falseValue:false'], ['falseValue' => false]],
+            'multiple values' => [
+                ['stringValue:thisIsString', 'trueValue:true'],
+                ['stringValue' => 'thisIsString', 'trueValue' => true],
+            ],
+        ];
+    }
+
+    public function testShouldNotAcceptCapabilitiesInWrongFormat()
+    {
+        $parser = new KeyValueCapabilityOptionsParser();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Capability must be given in format "capabilityName:value" but "foo" was given');
+        $parser->parse(['foo']);
+    }
+}

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -11,7 +11,6 @@ use Lmc\Steward\Process\Fixtures\DelayedTests\FirstTest;
 use Lmc\Steward\Publisher\AbstractPublisher;
 use Lmc\Steward\Publisher\XmlPublisher;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -264,14 +263,9 @@ class ProcessSetCreatorTest extends TestCase
             . ' --' . RunCommand::OPTION_FIXTURES_DIR . '=custom-fixtures-dir/'
             . ' --' . RunCommand::OPTION_LOGS_DIR . '=custom-logs-dir/'
             . ' --' . RunCommand::OPTION_CAPABILITY . '=webdriver.log.file:/foo/bar.log'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '="capability.in.quotes:/foo/ba r.log"'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '="platform:OS X 10.8"'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=stringValue:thisIsString'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=someNumber:1337'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=zeroValue:0'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=floatValue:1.337'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=trueValue:true'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=falseValue:false'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '="enquoted:OS X 10.8"'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=webdriver.foo:false'
+            . ' --' . RunCommand::OPTION_CAPABILITY . '=version:\"14.14393\"'
         );
 
         $this->input->bind($this->command->getDefinition());
@@ -298,45 +292,11 @@ class ProcessSetCreatorTest extends TestCase
                 'SERVER_URL' => 'http://foo.bar:1337',
                 'FIXTURES_DIR' => 'custom-fixtures-dir/',
                 'LOGS_DIR' => 'custom-logs-dir/',
-                'CAPABILITY' => '{'
-                    . '"webdriver.log.file":"\/foo\/bar.log",'
-                    . '"capability.in.quotes":"\/foo\/ba r.log",'
-                    . '"platform":"OS X 10.8",'
-                    . '"stringValue":"thisIsString",'
-                    . '"someNumber":1337,'
-                    . '"zeroValue":0,'
-                    . '"floatValue":1.337,'
-                    . '"trueValue":true,'
-                    . '"falseValue":false'
-                    . '}',
+                'CAPABILITY' => '{"webdriver.log.file":"\/foo\/bar.log","enquoted":"OS X 10.8","webdriver.foo":false,' .
+                    '"version":"14.14393"}',
             ],
             $processEnv
         );
-    }
-
-    public function testShouldNotAcceptCapabilitiesInWrongFormat()
-    {
-        $this->input = new StringInput(
-            'foo chrome'
-            . ' --' . RunCommand::OPTION_CAPABILITY . '=foo'
-        );
-
-        $this->input->bind($this->command->getDefinition());
-
-        // Redeclare creator so it uses the new input
-        $this->creator = new ProcessSetCreator(
-            $this->command,
-            $this->input,
-            $this->bufferedOutput,
-            $this->publisherMock
-        );
-
-        $files = $this->findDummyTests('DummyTest.php');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Capability must be given in format "capabilityName:value" but "foo" was given');
-
-        $this->creator->createFromFiles($files, [], []);
     }
 
     public function testShouldSetPHPUnitColoredOptionOnlyIfTheOutputIsDecorated()

--- a/src/Process/KeyValueCapabilityOptionsParser.php
+++ b/src/Process/KeyValueCapabilityOptionsParser.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Lmc\Steward\Process;
+
+use Symfony\Component\Console\Exception\RuntimeException;
+
+/**
+ * Parse colon delimited key:value capabilities passed as an CLI option
+ */
+class KeyValueCapabilityOptionsParser
+{
+    const DELIMITER = ':';
+
+    /**
+     * @param array $capabilities
+     * @return array
+     */
+    public function parse(array $capabilities)
+    {
+        $outputCapabilities = [];
+
+        foreach ($capabilities as $capability) {
+            $parts = explode(self::DELIMITER, $capability);
+            if (!isset($parts[0], $parts[1])) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Capability must be given in format "capabilityName:value" but "%s" was given',
+                        $capability
+                    )
+                );
+            }
+
+            $outputCapabilities[$parts[0]] = $this->castToGuessedDataType($parts[1]);
+        }
+
+        return $outputCapabilities;
+    }
+
+    /**
+     * Guest most appropriate data type acceptable by JSON
+     *
+     * @param string $value
+     * @return mixed
+     */
+    private function castToGuessedDataType($value)
+    {
+        $stringValueWithoutQuotes = $this->removeEncapsulatingQuotes($value);
+        if ($stringValueWithoutQuotes !== null) {
+            return $stringValueWithoutQuotes;
+        }
+
+        $intValue = filter_var($value, FILTER_VALIDATE_INT, []);
+        if ($intValue !== false) {
+            return $intValue;
+        }
+
+        $floatValue = filter_var($value, FILTER_VALIDATE_FLOAT, []);
+        if ($floatValue !== false) {
+            return $floatValue;
+        }
+
+        $boolValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]);
+        if ($boolValue !== null) {
+            return $boolValue;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return string|null
+     */
+    private function removeEncapsulatingQuotes($value)
+    {
+        $withoutDoubleQuotes = preg_replace('/^"(.+)"$/', '$1', $value);
+        if ($withoutDoubleQuotes !== $value) {
+            return $withoutDoubleQuotes;
+        }
+
+        $withoutSingleQuotes = preg_replace("/^'(.+)'$/", '$1', $value);
+        if ($withoutSingleQuotes !== $value) {
+            return $withoutSingleQuotes;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Currently the data type of capability value given on CLI is smartly guessed when converted to json for Selenium server:
- `--capability="platform:Linux"` => string `Linux`
- `--capability="foo:false"` => bool `false`
- `--capability="version:14.14393"` => number `14.14393`

However, in the last example, the version MUST be passed to selenium as a string (according to the WebDriver specification), otherwise Selenium server throws an error: `Uncaught Facebook\WebDriver\Exception\UnknownServerException: java.lang.Double cannot be cast to java.lang.String`. 

This means currently there is no way how to pass the version capability to the selenium server using `--capability` option, if it "looks" like a number 🙈.

So now you can force the value to be casted to a string,  even if it looks like a number, by encapsulating it in quotes (double or single). All following should work and pass the version as a string:
- `--capability="version:'14.14393'"`
- `--capability=version:\"14.14393\"`
- `--capability="version:\"14.14393\""`

Its also worth noting following WILL NOT work, because simple and double quotes will be usually "eaten" by the shell and not passed to the Steward command:
- `--capability=version:'14.14393'`
- `--capability=version:"14.14393"`
