### PR TITLE
Remove Configula dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Capabilities are now resolved using `CapabilitiesResolver` class.
 - Require PHPUnit ^5.7
+- Remove dependency on unmaintained Configula (and internally reimplement configuration options retrieval)
 
 ## 2.1.0 - 2017-01-16
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "clue/graph": "~0.9.0",
         "graphp/algorithms": "^0.8.1",
         "florianwolters/component-util-singleton": "0.3.2",
-        "caseyamcl/configula": "~2.3",
         "doctrine/inflector": "~1.0",
         "beberlei/assert": "^2.7",
         "ondram/ci-detector": "^2.0"

--- a/src-tests/ConfigHelper.php
+++ b/src-tests/ConfigHelper.php
@@ -5,7 +5,7 @@ namespace Lmc\Steward;
 class ConfigHelper
 {
     /**
-     * Unset config instance from the singleton, so next time the config will be get, it will be recreated from
+     * Unset config value from the singleton, so next time the config will be get, it will be recreated from
      * current (and possibly adjusted to our needs) environment variables.
      */
     public static function unsetConfigInstance()

--- a/src-tests/Selenium/CapabilitiesResolverTest.php
+++ b/src-tests/Selenium/CapabilitiesResolverTest.php
@@ -26,7 +26,13 @@ class CapabilitiesResolverTest extends TestCase
         $test = $this->getMockForAbstractClass(AbstractTestCase::class, ['name'], 'FooBarTest');
 
         $configMock = $this->createMock(ConfigProvider::class);
-        $configMock->browserName = $browser;
+        $configMock->expects($this->any())
+            ->method('__get')
+            ->willReturnMap(
+                [
+                    ['browserName', $browser],
+                ]
+            );
 
         $resolver = new CapabilitiesResolver($configMock);
         $resolver->setCiDetector($this->createConfiguredMock(CiDetector::class, ['isCiDetected' => false]));
@@ -75,8 +81,14 @@ class CapabilitiesResolverTest extends TestCase
         $test = $this->getMockForAbstractClass(AbstractTestCase::class, ['name'], 'FooBarTest');
 
         $configMock = $this->createMock(ConfigProvider::class);
-        $configMock->browserName = WebDriverBrowserType::FIREFOX;
-        $configMock->env = 'staging';
+        $configMock->expects($this->any())
+            ->method('__get')
+            ->willReturnMap(
+                [
+                    ['browserName', WebDriverBrowserType::FIREFOX],
+                    ['env', 'staging'],
+                ]
+            );
 
         $ciMock = $this->createConfiguredMock(Jenkins::class, ['getBuildNumber' => 1337, 'getCiName' => 'Jenkins']);
         $ciDetectorMock = $this->createConfiguredMock(


### PR DESCRIPTION
The Configula library is unmaintained, we use only small fraction of it and it also blocks from using symfony/yaml 3.x (which is required for some upcoming WIP Steward features).

The change should be BC and will not require any change in tests. Hopefully :).