### PR TITLE
Fix misleading exception shown eg. when data provider is invalid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Attempting to download not existing Selenium server version (with `install` command) will not create empty jar file but only show an error.
+- Fix misleading exception "Test case must be descendant of Lmc\Steward\Test\AbstractTestCase" when invalid data provider is used.
 
 ## 2.1.0 - 2017-01-16
 ### Added

--- a/src-tests/Listener/Fixtures/ExceptionThrowingPublisher.php
+++ b/src-tests/Listener/Fixtures/ExceptionThrowingPublisher.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lmc\Steward\Listener\Fixtures;
+
+use Lmc\Steward\Publisher\AbstractPublisher;
+
+/**
+ * Throw an exception anytime its public methods are called
+ */
+class ExceptionThrowingPublisher extends AbstractPublisher
+{
+    public function publishResults(
+        $testCaseName,
+        $status,
+        $result = null,
+        \DateTimeInterface $startDate = null,
+        \DateTimeInterface $endDate = null
+    ) {
+        throw new \LogicException('publishResults() called');
+    }
+
+    public function publishResult(
+        $testCaseName,
+        $testName,
+        \PHPUnit_Framework_Test $testInstance,
+        $status,
+        $result = null,
+        $message = null
+    ) {
+        throw new \LogicException('publishResult() called');
+    }
+}

--- a/src-tests/Listener/TestStatusListenerTest.php
+++ b/src-tests/Listener/TestStatusListenerTest.php
@@ -4,6 +4,7 @@ namespace Lmc\Steward\Listener;
 
 use Lmc\Steward\ConfigHelper;
 use Lmc\Steward\Listener\Fixtures\DummyPublisher;
+use Lmc\Steward\Listener\Fixtures\ExceptionThrowingPublisher;
 use Lmc\Steward\Publisher\SauceLabsPublisher;
 use Lmc\Steward\Publisher\TestingBotPublisher;
 use Lmc\Steward\Selenium\SeleniumServerAdapter;
@@ -24,6 +25,20 @@ class TestStatusListenerTest extends TestCase
         $configValues['DEBUG'] = 1;
         ConfigHelper::setEnvironmentVariables($configValues);
         ConfigHelper::unsetConfigInstance();
+    }
+
+    public function testShouldNotDoAnythingWhenWarningTestCaseOccurs()
+    {
+        $publishers = [ExceptionThrowingPublisher::class];
+
+        $listener = new TestStatusListener($publishers, $this->seleniumAdapterMock);
+
+        $warningTestCase = new \PHPUnit_Framework_WarningTestCase('Warning');
+
+        $listener->startTest($warningTestCase);
+        $listener->endTest($warningTestCase, 1);
+
+        $this->expectOutputRegex('/^((?!Error publishing).)*$/s');
     }
 
     public function testShouldRegisterXmlPublisherByDefault()

--- a/src/Listener/TestStatusListener.php
+++ b/src/Listener/TestStatusListener.php
@@ -10,7 +10,6 @@ use Lmc\Steward\Publisher\TestingBotPublisher;
 use Lmc\Steward\Publisher\XmlPublisher;
 use Lmc\Steward\Selenium\SeleniumServerAdapter;
 use PHPUnit\Framework\BaseTestListener;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Listener to log status of test case and at the end of suite publish them using registered publishers.
@@ -77,9 +76,10 @@ class TestStatusListener extends BaseTestListener
 
     public function startTest(\PHPUnit_Framework_Test $test)
     {
-        if (!$test instanceof TestCase || $test instanceof \PHPUnit_Framework_Warning) {
+        if (!$test instanceof \PHPUnit_Framework_TestCase || $test instanceof \PHPUnit_Framework_WarningTestCase) {
             return;
         }
+
         // publish test status to all publishers
         foreach ($this->publishers as $publisher) {
             try {
@@ -102,9 +102,10 @@ class TestStatusListener extends BaseTestListener
 
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
-        if (!$test instanceof TestCase || $test instanceof \PHPUnit_Framework_Warning) {
+        if (!$test instanceof \PHPUnit_Framework_TestCase || $test instanceof \PHPUnit_Framework_WarningTestCase) {
             return;
         }
+
         // publish test status to all publishers
         foreach ($this->publishers as $publisher) {
             try {

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -52,7 +52,7 @@ class WebDriverListener extends BaseTestListener
 
     public function startTest(\PHPUnit_Framework_Test $test)
     {
-        if ($test instanceof \PHPUnit_Framework_Warning) {
+        if ($test instanceof \PHPUnit_Framework_WarningTestCase) {
             return;
         }
 
@@ -103,7 +103,7 @@ class WebDriverListener extends BaseTestListener
 
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
-        if ($test instanceof \PHPUnit_Framework_Warning) {
+        if ($test instanceof \PHPUnit_Framework_WarningTestCase) {
             return;
         }
 


### PR DESCRIPTION
Fixes #127.

`\PHPUnit_Framework_Warning` was used instead of `\PHPUnit_Framework_WarningTestCase`.