### PR TITLE
Print total and testcase execution times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 ### Added
 - Capabilities passed using `--capability` CLI option could now force to be specified as an string (by encapsulating into additional quotes).
+- Print total execution time at the end; in `-vv` and `-vvv` modes print also execution after each testcase is finished.
 
 ### Changed
 - Capabilities are now resolved using `CapabilitiesResolver` class.

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "symfony/finder": "~3.0",
         "symfony/event-dispatcher": "~3.0",
         "symfony/filesystem": "~3.0",
+        "symfony/stopwatch": "^3.0",
         "nette/reflection": "^2.3.2",
         "nette/utils": "~2.3",
         "facebook/webdriver": "^1.4.0",

--- a/src-tests/Console/Command/Fixtures/FailingTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/FailingTests/expected-debug-output.txt
@@ -9,8 +9,8 @@ Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> 1) Lmc\Steward\Co
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> Sorry :-(%A
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> FAILURES!
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> Tests: 1, Assertions: 0, Failures: 1.%A
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest" (result: failed)
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest" (result: failed, time: %f sec)
 [%s] Failing testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\DependantTest", because it was depending on failed "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest"
 [%s] Waiting (running: 0, queued: 0, done: 2 [failed: 2])
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[ERROR] Testcases executed: 2 (failed: 2)%A

--- a/src-tests/Console/Command/Fixtures/FailingTests/expected-normal-output.txt
+++ b/src-tests/Console/Command/Fixtures/FailingTests/expected-normal-output.txt
@@ -2,5 +2,5 @@ Steward UNKNOWN is running the tests...%S
 
 [%s] Waiting (running: 1, queued: 1, done: 0)%A
 [%s] Waiting (running: 0, queued: 0, done: 2 [failed: 2])
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[ERROR] Testcases executed: 2 (failed: 2)%A

--- a/src-tests/Console/Command/Fixtures/FailingTests/expected-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/FailingTests/expected-verbose-output.txt
@@ -6,5 +6,5 @@ Environment: staging
 [%s] Testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest" failed
 [%s] Failing testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\DependantTest", because it was depending on failed "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest"
 [%s] Waiting (running: 0, queued: 0, done: 2 [failed: 2])
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[ERROR] Testcases executed: 2 (failed: 2)%A

--- a/src-tests/Console/Command/Fixtures/FailingTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/FailingTests/expected-very-verbose-output.txt
@@ -13,7 +13,7 @@ Starting execution of testcases
 -------------------------------
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest" started
 [%s] Waiting (running: 1, queued: 1, done: 0)%A
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest" (result: failed), output:%A
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest" (result: failed, time: %f sec), output:%A
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> There was 1 failure:%A
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> 1) Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest::testThatWillFail%A
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> Sorry :-(%A
@@ -21,5 +21,5 @@ Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> FAILURES!%A
 Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest> Tests: 1, Assertions: 0, Failures: 1.%A
 [%s] Failing testcase "Lmc\Steward\Console\Command\Fixtures\FailingTests\DependantTest", because it was depending on failed "Lmc\Steward\Console\Command\Fixtures\FailingTests\FailingTest"
 [%s] Waiting (running: 0, queued: 0, done: 2 [failed: 2])
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[ERROR] Testcases executed: 2 (failed: 2)%A

--- a/src-tests/Console/Command/Fixtures/NoBrowserTests/expected-output.txt
+++ b/src-tests/Console/Command/Fixtures/NoBrowserTests/expected-output.txt
@@ -1,7 +1,7 @@
 %a
 Lmc\Steward\Console\Command\Fixtures\NoBrowserTests\NoBrowserTest> [%s]: Initializing Null WebDriver for "Lmc\Steward\Console\Command\Fixtures\NoBrowserTests\NoBrowserTest::testDummy" (@noBrowser annotation used on class)
 %a
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\NoBrowserTests\NoBrowserTest" (result: passed)
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\NoBrowserTests\NoBrowserTest" (result: passed, time: %f sec)
 %a
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[OK] Testcases executed: 1 (passed: 1)%A

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
@@ -35,7 +35,7 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest>     [0] => fooBarDa
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> )%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Finished execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> OK (1 test, 1 assertion)%A
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed)%A
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed, time: %f sec)%A
 [%s] Unqueing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" started with command:
 '%s/vendor/bin/phpunit' '--log-junit=logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-DependantTest.xml' '--configuration=%s/phpunit.xml' '%s/DependantTest.php'
@@ -53,7 +53,7 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest>     [0] => fooBa
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> )%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Finished execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> OK (1 test, 1 assertion)%A
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" (result: passed)
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" (result: passed, time: %f sec)
 [%s] Waiting (running: 0, queued: 0, done: 2 [passed: 2])
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[OK] Testcases executed: 2 (passed: 2)%A

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-normal-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-normal-output.txt
@@ -1,5 +1,5 @@
 Steward UNKNOWN is running the tests...%S
 
 [%s] Waiting (running: 1, queued: 1, done: 0)%A
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[OK] Testcases executed: 2 (passed: 2)%A

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-verbose-output.txt
@@ -3,5 +3,5 @@ Browser: firefox
 Environment: staging
 
 [%s] Waiting (running: 1, queued: 1, done: 0)%A
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[OK] Testcases executed: 2 (passed: 2)%A

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
@@ -12,10 +12,10 @@ Searching for testcases:
 Starting execution of testcases
 -------------------------------
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" started%A
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed)%A
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed, time: %f sec)%A
 [%s] Unqueing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" started%A
-[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" (result: passed)
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" (result: passed, time: %f sec)
 [%s] Waiting (running: 0, queued: 0, done: 2 [passed: 2])
-[%s] All testcases done
+[%s] All testcases done in %f seconds
 %A[OK] Testcases executed: 2 (passed: 2)%A


### PR DESCRIPTION
Print to console total execution time at the end. When in very verbose (`-vv`) or debug (`-vvv`) modes are used, print also execution after each testcase is finished.

![execution-time](https://cloud.githubusercontent.com/assets/793041/25309208/f0195236-27c6-11e7-9912-ab62ea707f21.png)
