### PR TITLE
Simplify dependencies - replace Nette\Utils with custom filename sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Require PHPUnit ^5.7
 - Remove dependency on unmaintained Configula (and internally reimplement configuration options retrieval)
 - Improve `install` command output (eg. to always include path to downloaded file).
+- Use custom method `Strings::toFilename` to convert class name to file name (and remove direct Composer dependency on `nette/utils`).
 
 ### Fixed
 - Attempting to download not existing Selenium server version (with `install` command) will not create empty jar file but only show an error.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "symfony/event-dispatcher": "~3.0",
         "symfony/filesystem": "~3.0",
         "nette/reflection": "^2.3.2",
-        "nette/utils": "~2.3",
         "facebook/webdriver": "^1.4.0",
         "clue/graph": "~0.9.0",
         "graphp/algorithms": "^0.8.1",

--- a/src-tests/Utils/StringsTest.php
+++ b/src-tests/Utils/StringsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Lmc\Steward\Timeline;
+
+use Lmc\Steward\Utils\Strings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Lmc\Steward\Utils\Strings
+ */
+class StringsTest extends TestCase
+{
+    /**
+     * @dataProvider provideStringToFilename
+     * @param string $string
+     * @param string $expectedFilename
+     */
+    public function testShouldCOnvertStringToFilename($string, $expectedFilename)
+    {
+        $this->assertSame($expectedFilename, Strings::toFilename($string));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideStringToFilename()
+    {
+        return [
+            'Convert special chars in class name, keep case' => ['Lmc\Foo\FooBarTest', 'Lmc-Foo-FooBarTest'],
+            'Convert special charts in FQN' => ['Lmc\Foo\FooBarTest::bazBan', 'Lmc-Foo-FooBarTest-bazBan'],
+            'Convert other special chars' => ['f"o&o/b\'a_r', 'f-o-o-b-a-r'],
+            'Convert national chars, do no transliteration' => ['foo žluťoučký KŮŇ bar', 'foo-lu-ou-k-K-bar'],
+            'Only one hyphen in sequence' => ['foo-----bar', 'foo-bar'],
+            'No hyphens on start or end' => ['&foo&bar&', 'foo-bar'],
+            'No hyphens on start or end when spaces encapsulate the text' => ['  foo  ', 'foo'],
+            'Only special char => empty string' => ['&', ''],
+            'Only spaces => empty string' => ['     ', ''],
+            'Empty string => do nothing' => ['', ''],
+            'Multiple special chars in sequence => only one hyphen' => ['foo///BAR', 'foo-BAR'],
+            'Multiple national chars in sequence => only one hyphen' => ['fooĎŤŇBAR', 'foo-BAR'],
+        ];
+    }
+}

--- a/src/Component/Legacy.php
+++ b/src/Component/Legacy.php
@@ -53,7 +53,7 @@ namespace Lmc\Steward\Component;
 
 use Lmc\Steward\ConfigProvider;
 use Lmc\Steward\Test\AbstractTestCaseBase;
-use Nette\Utils\Strings;
+use Lmc\Steward\Utils\Strings;
 
 /**
  * Legacy component allows you to share data between test-cases and phases of tests.
@@ -115,10 +115,10 @@ class Legacy extends AbstractComponent
         }
 
         $name = preg_replace('/Phase\d/', '', $name); // remove 'PhaseX' from the name
-        $name = Strings::webalize($name, null, $lower = false);
+        $name = Strings::toFilename($name);
 
         if ($type == self::LEGACY_TYPE_TEST) {
-            $name .= '#' . Strings::webalize($this->tc->getName(false), null, $lower = false);
+            $name .= '#' . Strings::toFilename($this->tc->getName(false));
         }
 
         return $name;

--- a/src/Listener/SnapshotListener.php
+++ b/src/Listener/SnapshotListener.php
@@ -6,7 +6,7 @@ use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Lmc\Steward\ConfigProvider;
 use Lmc\Steward\Test\AbstractTestCase;
-use Nette\Utils\Strings;
+use Lmc\Steward\Utils\Strings;
 use PHPUnit\Framework\BaseTestListener;
 
 /**
@@ -96,8 +96,8 @@ class SnapshotListener extends BaseTestListener
     {
         return sprintf(
             '%s-%s-%s',
-            Strings::webalize(get_class($testCase), null, $lower = false),
-            Strings::webalize($testCase->getName(), null, $lower = false),
+            Strings::toFilename(get_class($testCase)),
+            Strings::toFilename($testCase->getName()),
             date('Y-m-d-H-i-s')
         );
     }

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -6,8 +6,8 @@ use Lmc\Steward\Console\Command\RunCommand;
 use Lmc\Steward\Console\CommandEvents;
 use Lmc\Steward\Console\Event\RunTestsProcessEvent;
 use Lmc\Steward\Publisher\AbstractPublisher;
+use Lmc\Steward\Utils\Strings;
 use Nette\Reflection\AnnotationsParser;
-use Nette\Utils\Strings;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
@@ -125,7 +125,7 @@ class ProcessSetCreator
 
             $phpunitArgs = [
                 '--log-junit=logs/'
-                . Strings::webalize($className, null, $lower = false)
+                . Strings::toFilename($className)
                 . '.xml',
                 '--configuration=' . realpath(__DIR__ . '/../phpunit.xml'),
             ];

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lmc\Steward\Utils;
+
+class Strings
+{
+    /**
+     * Convert given string to safe filename (and keep string case).
+     *
+     * No transliteration, conversion etc. is done - unsafe characters are simply replaced with hyphen.
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function toFilename($string)
+    {
+        return trim(preg_replace('/([^a-zA-Z0-9]|-)+/', '-', $string), '-');
+    }
+}


### PR DESCRIPTION
We only use fraction of Nette\Utils - actually only the `Strings::webalize()` method.

Moreover, we don't need power of this method: we just use is to convert FQN to some sane filename. 

And simple online method is more than enough for this purpose.

(However the nette/utils is still installed by nette/reflection, but this is first step how to remove this dependency, because we will probably use some different annotations parser in future.)

BTW initial impulse for this change was https://github.com/composer/composer/issues/6334 , which was also resolved meanwhile :).