### PR TITLE
Workaround for confusing order of test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Fixed
 - Attempting to download not existing Selenium server version (with `install` command) will not create empty jar file but only show an error.
-- Fix misleading exception "Test case must be descendant of Lmc\Steward\Test\AbstractTestCase" when invalid data provider is used.
+- Do not throw misleading exception "Test case must be descendant of Lmc\Steward\Test\AbstractTestCase" when invalid data provider is used.
+- Debug messages about destroying WebDriver instance on the end of each test were printed to the output before output of the actual tests.
 
 ## 2.1.0 - 2017-01-16
 ### Added

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
@@ -19,9 +19,6 @@ Testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" is prepar
 [%s] Waiting (running: 1, queued: 1, done: 0)%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Registering test results publisher "Lmc\Steward\Publisher\XmlPublisher"%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Initializing "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage"%A
-Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Destroying "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage" (session %s)
-Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Executing command "close" with params []%A
-Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Executing command "quit" with params []%A
 %A[%s]: Starting execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage%aLmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Executing command "setWindowSize" with params {"width":1280,"height":1024,":windowHandle":"current"}
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Loading URL "file:///%s/src-tests/Console/Command/Fixtures/SimpleTests/webpage.html"%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Executing command "get" with params {"url":"file:///%s/webpage.html"}%A
@@ -34,6 +31,9 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> (
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest>     [0] => fooBarData
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> )%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Finished execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage%A
+Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Destroying "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage" (session %s)
+Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Executing command "close" with params []%A
+Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: [WebDriver] Executing command "quit" with params []%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> OK (1 test, 1 assertion)%A
 [%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed, time: %f sec)%A
 [%s] Unqueing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
@@ -41,9 +41,6 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> OK (1 test, 1 asser
 '%s/vendor/bin/phpunit' '--log-junit=logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-DependantTest.xml' '--configuration=%s/phpunit.xml' '%s/DependantTest.php'
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Registering test results publisher "Lmc\Steward\Publisher\XmlPublisher"%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Initializing "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar"%A
-Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Destroying "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar" (session %s)
-Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [WebDriver] Executing command "close" with params []%A
-Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [WebDriver] Executing command "quit" with params []%A
 %a[%s]: Starting execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar%aLmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [WebDriver] Executing command "setWindowSize" with params {"width":1280,"height":1024,":windowHandle":"current"}
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [Legacy] New Legacy instantiated in class "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [Legacy] Reading Legacy "dummy-data" from file "%s/dummy-data.legacy"
@@ -52,6 +49,9 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> (
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest>     [0] => fooBarData
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> )%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Finished execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar%A
+Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Destroying "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar" (session %s)
+Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [WebDriver] Executing command "close" with params []%A
+Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [WebDriver] Executing command "quit" with params []%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> OK (1 test, 1 assertion)%A
 [%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" (result: passed, time: %f sec)
 [%s] Waiting (running: 0, queued: 0, done: 2 [passed: 2])

--- a/src-tests/Listener/SnapshotListenerTest.php
+++ b/src-tests/Listener/SnapshotListenerTest.php
@@ -77,9 +77,11 @@ class SnapshotListenerTest extends TestCase
 
         $output = $test->getActualOutput();
         $this->assertStringMatchesFormat(
-            '[%s]: Test failed on page "http://foo.bar", taking page snapshots:
-[%s]: Screenshot saved to file "%s/steward/src-tests/' . $expectedFileNameBase . '-%s.png" 
-[%s]: HTML snapshot saved to file "%s/steward/src-tests/' . $expectedFileNameBase . '-%s.html"%A',
+            '[%s]:%S
+[%s]: [WARN] Test failed on page "http://foo.bar", taking page snapshots:
+[%s]: Screenshot: "%s/steward/src-tests/' . $expectedFileNameBase . '-%s.png"
+[%s]: HTML snapshot: "%s/steward/src-tests/' . $expectedFileNameBase . '-%s.html"
+[%s]:%S',
             $output
         );
     }

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -74,6 +74,17 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
         $this->appendedTestLog .= $output;
     }
 
+    /**
+     * Append already formatted log (including timestamp, newlines etc.) to end of test's log.
+     *
+     * @param string $formattedLog
+     * @see appendTestLog
+     */
+    public function appendFormattedTestLog($formattedLog)
+    {
+        $this->appendedTestLog .= $formattedLog;
+    }
+
     public function log($format, ...$args)
     {
         echo $this->formatOutput($format, $args);

--- a/src/WebDriver/RemoteWebDriver.php
+++ b/src/WebDriver/RemoteWebDriver.php
@@ -5,7 +5,7 @@ namespace Lmc\Steward\WebDriver;
 use Lmc\Steward\ConfigProvider;
 
 /**
- * Extends RemoteWebDriver with some extra logic, ie. more verbose logging.
+ * Extends RemoteWebDriver with some extra logic, eg. more verbose logging.
  */
 class RemoteWebDriver extends \Facebook\WebDriver\Remote\RemoteWebDriver
 {


### PR DESCRIPTION
The issue is obvious from the changes made in test fixture:
https://github.com/lmc-eu/steward/compare/master...OndraM:fix/output-order-workaround?expand=1#diff-ec6327666d6d87ae77da1564135aa57b

The cause is in PHPUnit Listener orders - the PHPUnit's `ResultPrinter` class, which prints the test output  and is also a listener, is registered as the last one, while `WebDriverListener` is registered before this one. So anything printed from `WebDriverListener` (or any other Listener) makes its way to the output before the actual output of the test.

This is kind of workaround; the long-term solution (which is also required for PHPUnit 6 upgrade) is to move WebDriver instantiation to custom `PHPUnit_Extensions_TestDecorator` (or `PHPUnit_TextUI_TestRunner`), which will introduce new options how to handle the output.