### PR TITLE
Show total time of each testcase in results.xml file & other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 - Capabilities passed using `--capability` CLI option could now force to be specified as an string (by encapsulating into additional quotes).
 - Print total execution time at the end; in `-vv` and `-vvv` modes print also execution after each testcase is finished.
-- Show total execution of each testcase when viewing result.xml file via browser (currently only execution time of each test was shown).
+- Show total execution of each testcase when viewing result.xml file via browser (currently only execution time of each test was shown). Also show full test name (including testcase name) when hovering over its name.
 
 ### Changed
 - Capabilities are now resolved using `CapabilitiesResolver` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Capabilities passed using `--capability` CLI option could now force to be specified as an string (by encapsulating into additional quotes).
 - Print total execution time at the end; in `-vv` and `-vvv` modes print also execution after each testcase is finished.
+- Show total execution of each testcase when viewing result.xml file via browser (currently only execution time of each test was shown).
 
 ### Changed
 - Capabilities are now resolved using `CapabilitiesResolver` class.

--- a/src/Resources/results.xsl
+++ b/src/Resources/results.xsl
@@ -225,7 +225,7 @@
                     window.wasInitialized = true;
 
                     // calculate and print test duration
-                    $('table tr.test-row').each(function() {
+                    $('table tr.test-row, table tr.testcase-row').each(function() {
                         var startDate = moment($('td.date-start', this).text());
                         var endValue = $('td.date-end', this).text();
                         var endDate = moment(endValue);

--- a/src/Resources/results.xsl
+++ b/src/Resources/results.xsl
@@ -96,7 +96,7 @@
                         </div>
                     </div>
 
-                    <table class="table table-condensed table-striped table-hover">
+                    <table class="table table-condensed table-hover">
                         <thead>
                             <tr>
                                 <th colspan="2">Testcase / tests</th>
@@ -109,7 +109,7 @@
                         </thead>
                         <tbody>
                             <xsl:for-each select="//testcases/testcase">
-                                <tr class="testcase-row">
+                                <tr class="testcase-row active">
                                     <td colspan="2" style="word-break: break-all;">
                                         <xsl:value-of select="@name"/>
                                     </td>

--- a/src/Resources/results.xsl
+++ b/src/Resources/results.xsl
@@ -96,7 +96,7 @@
                         </div>
                     </div>
 
-                    <table class="table table-condensed table-hover">
+                    <table class="table table-condensed table-hover results-table">
                         <thead>
                             <tr>
                                 <th colspan="2">Testcase / tests</th>
@@ -157,6 +157,9 @@
                                         <tr class="test-row">
                                             <td></td>
                                             <td style="word-break: break-all;">
+                                                <xsl:attribute name="title">
+                                                    <xsl:value-of select="../@name"/>::<xsl:value-of select="@name"/>
+                                                </xsl:attribute>
                                                 <xsl:value-of select="@name"/>
                                             </td>
                                             <td>


### PR DESCRIPTION
## Before
![screenshot_20170505_131607](https://cloud.githubusercontent.com/assets/793041/25744250/10e2daba-3199-11e7-81ea-4d8c2752a30b.png)

## After
- total time of each testcase is shown (it is already shown when running `steward results`)
- table is not stripped
- instead  the background emphasizing is used for testcases
- hovering over test name shows its full name in title tooltip (including testcase FQN)

![screenshot_20170505_134845](https://cloud.githubusercontent.com/assets/793041/25744333/aef8a4b4-3199-11e7-92a0-e2b2c0bece70.png)
