### PR TITLE
Fix run option --logs-dir

### DIFF
--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -289,7 +289,8 @@ class RunCommand extends Command
             $input->getOption(self::OPTION_GROUP),
             $input->getOption(self::OPTION_EXCLUDE_GROUP),
             $input->getOption(self::OPTION_FILTER),
-            $input->getOption(self::OPTION_IGNORE_DELAYS)
+            $input->getOption(self::OPTION_IGNORE_DELAYS),
+            $input->getOption(self::OPTION_LOGS_DIR)
         );
 
         if (!count($processSet)) {

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -66,7 +66,7 @@ class ProcessSetCreator
         array $excludeGroups,
         $filter = null,
         $ignoreDelays = false,
-        $logsDir = 'logs/'
+        $logsDir = 'logs'
     ) {
         $files->sortByName();
         $processSet = $this->getProcessSet();

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -57,6 +57,7 @@ class ProcessSetCreator
      * @param array $excludeGroups Groups to be excluded
      * @param string $filter filter test cases by name
      * @param bool $ignoreDelays Should test delays be ignored?
+     * @param string $logsDir Where to write junit logs
      * @return ProcessSet
      */
     public function createFromFiles(
@@ -64,7 +65,8 @@ class ProcessSetCreator
         array $groups,
         array $excludeGroups,
         $filter = null,
-        $ignoreDelays = false
+        $ignoreDelays = false,
+        $logsDir = 'logs/'
     ) {
         $files->sortByName();
         $processSet = $this->getProcessSet();
@@ -124,7 +126,7 @@ class ProcessSetCreator
             }
 
             $phpunitArgs = [
-                '--log-junit=logs/'
+                '--log-junit=' . $logsDir . '/'
                 . Strings::toFilename($className)
                 . '.xml',
                 '--configuration=' . realpath(__DIR__ . '/../phpunit.xml'),


### PR DESCRIPTION
run allow to specify a custom logs dir but this directory is not taken into
account when running phpunit afterward.

This is useful when you don't have write access to the directory where tests
are defined & run