### PR TITLE
Hotfix: temporarily require symfony/console <3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-zip": "*",
         "ext-curl": "*",
         "phpunit/phpunit": "^5.7",
-        "symfony/console": "~3.0",
+        "symfony/console": "~3.0 <3.3",
         "symfony/process": "^3.2.0",
         "symfony/finder": "~3.0",
         "symfony/event-dispatcher": "~3.0",


### PR DESCRIPTION
Symfony/console 3.3.0 released few days ago breaks some tests - see #145.

This constrain is a hotfix for #145 unit we will find the cause and impact of the issue. (It may just broke the tests and have no impact on Steward...)
