### PR TITLE
Fix symfony/console 3.3.0 incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 ### Fixed
 - Minor Windows compatibility issues (dir paths passed to run command now respect system directory separator etc.).
+- Compatibility with Symfony/Console 3.3 (`--xdebug` option behavior was incorrect with symfony/console 3.3.0).
 
 ## 2.2.0 - 2017-05-12
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-zip": "*",
         "ext-curl": "*",
         "phpunit/phpunit": "^5.7",
-        "symfony/console": "~3.0 <3.3",
+        "symfony/console": "^3.3.0",
         "symfony/process": "^3.2.0",
         "symfony/finder": "~3.0",
         "symfony/event-dispatcher": "~3.0",


### PR DESCRIPTION
Behavior changed in https://github.com/symfony/symfony/pull/21228 (symfony 3.3.0). So installing latest stable versions of Steward dependencies will cause the behavior of `--xdebug` to break.