### PR TITLE
Trim selenium hub endpoint from server URL if passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Changed
+- If url endpoint (`/wd/hub`) is passed as part of server URL, it is automatically trimmed, as it is not necessary and will cause connection error.
 
 ## 2.2.1 - 2017-06-06
 ### Fixed

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -99,6 +99,38 @@ class SeleniumServerAdapterTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideServerUrlWithHubEndpoint
+     * @param string $providedServerUrl
+     * @param string $expectedServerUrl
+     */
+    public function testShouldTrimHubEndpointFromTheServerUrl($providedServerUrl, $expectedServerUrl)
+    {
+        $adapter = new SeleniumServerAdapter($providedServerUrl);
+
+        $this->assertSame($expectedServerUrl, $adapter->getServerUrl());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideServerUrlWithHubEndpoint()
+    {
+        return [
+            'No endpoint, URL with port' => ['http://localhost:4444', 'http://localhost:4444'],
+            'No endpoint, URL without port' => ['http://localhost', 'http://localhost:4444'],
+            'Endpoint defined, with port' => ['http://localhost:4444/wd/hub', 'http://localhost:4444'],
+            'Endpoint defined, without port' => ['http://localhost/wd/hub', 'http://localhost:4444'],
+            'Endpoint with trailing slash & port' => ['http://localhost:4444/wd/hub/', 'http://localhost:4444'],
+            'Endpoint with trailing slash & without port' => ['http://localhost/wd/hub/', 'http://localhost:4444'],
+            'Not a hub endpoint should be kept' => ['http://localhost/foo/bar', 'http://localhost:4444/foo/bar'],
+            'Not a hub endpoint (with port) should be kept' => [
+                'http://localhost:1337/foo/bar',
+                'http://localhost:1337/foo/bar',
+            ],
+        ];
+    }
+
     public function testShouldReturnTrueIfUrlIsAccessible()
     {
         $dummyResource = fopen(__FILE__, 'r');

--- a/src/Selenium/SeleniumServerAdapter.php
+++ b/src/Selenium/SeleniumServerAdapter.php
@@ -182,6 +182,10 @@ class SeleniumServerAdapter
             $urlParts['port'] = $this->guessPort($urlParts['host']);
         }
 
+        if (!empty($urlParts['path'])) {
+            $urlParts['path'] = $this->removeHubEndpointPathIfPresent($urlParts['path']);
+        }
+
         return $urlParts;
     }
 
@@ -200,6 +204,21 @@ class SeleniumServerAdapter
         }
 
         return self::DEFAULT_PORT;
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    protected function removeHubEndpointPathIfPresent($path)
+    {
+        $path = preg_replace(
+            '/^(.*)(' . preg_quote(self::HUB_ENDPOINT, '/') . '\/?)$/',
+            '$1',
+            $path
+        );
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
Currently custom server URL must not contain the WebDriver hub path (`/wd/hub`), because Steward adds it by itself. This may be confusing, because other Selenium tools usually uses it.

This change makes Steward accept both URL without this part (what is current behavior) or with this path (it is then internally stripped).

```sh
# currently required format:
$ ./bin/steward run prod chrome --server-url=http://...@ondemand.saucelabs.com:80
$ ./bin/steward run prod chrome --server-url=http://localhost:4444

# would fail until now, works with this path as well:
$ ./bin/steward run prod chrome --server-url=http://...@ondemand.saucelabs.com:80/wd/hub 
$ ./bin/steward run prod chrome --server-url=http://localhost:4444/wd/hub
$ ./bin/steward run prod chrome --server-url=http://localhost:4444/wd/hub/ # also accepts trailing slash
```
