### PR TITLE
Work with custom bin-dir composer config.

### DIFF
--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -196,7 +196,7 @@ class ProcessSetCreator
             ->setEnv('FIXTURES_DIR', $this->config[ConfigOptions::FIXTURES_DIR])
             ->setEnv('LOGS_DIR', $this->config[ConfigOptions::LOGS_DIR])
             ->setEnv('DEBUG', $this->output->isDebug() ? '1' : '0')
-            ->setPrefix(STEWARD_BASE_DIR . '/vendor/phpunit/phpunit/phpunit')
+            ->setPrefix(__DIR__ . '/../../../../phpunit/phpunit/phpunit')
             ->setArguments(array_merge($processEvent->getArgs(), [$fileName]))
             ->setTimeout(3600); // 1 hour timeout to end possibly stuck processes
 

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -196,7 +196,7 @@ class ProcessSetCreator
             ->setEnv('FIXTURES_DIR', $this->config[ConfigOptions::FIXTURES_DIR])
             ->setEnv('LOGS_DIR', $this->config[ConfigOptions::LOGS_DIR])
             ->setEnv('DEBUG', $this->output->isDebug() ? '1' : '0')
-            ->setPrefix(STEWARD_BASE_DIR . '/vendor/bin/phpunit')
+            ->setPrefix(STEWARD_BASE_DIR . '/vendor/phpunit/phpunit/phpunit')
             ->setArguments(array_merge($processEvent->getArgs(), [$fileName]))
             ->setTimeout(3600); // 1 hour timeout to end possibly stuck processes
 


### PR DESCRIPTION
When someone installs Steward in an application that has a [custom `bin-dir` config](https://getcomposer.org/doc/articles/vendor-binaries.md#can-vendor-binaries-be-installed-somewhere-other-than-vendor-bin-) in their composer.json, steward execute run, because it's looking for phpunit always in a binary directory called `vendor/bin`.

This change just makes sure we call the actual phpunit/phpunit binray is used from the vendor directory (because also `vendor-dir` is a configurable value) ... maybe it's better to allow a custom config parameter? 