### PR TITLE
Don't rely on default path to PHPUnit binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Base directory (which affects default paths to tests, logs etc.) is now properly detected even when Steward is not installed in `/vendor` directory.
+- Don't rely on default path to PHPUnit binary (`vendor/bin/phpunit`) to allow custom `bin-dir` and `vendor-dir` Composer settings.
 
 ## 2.2.1 - 2017-06-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Changed
 - If url endpoint (`/wd/hub`) is passed as part of server URL, it is automatically trimmed, as it is not necessary and will cause connection error.
 
+### Fixed
+- Base directory (which affects default paths to tests, logs etc.) is now properly detected even when Steward is not installed in `/vendor` directory.
+
 ## 2.2.1 - 2017-06-06
 ### Fixed
 - Minor Windows compatibility issues (dir paths passed to run command now respect system directory separator etc.).

--- a/bin/phpunit-steward
+++ b/bin/phpunit-steward
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 
 function requireIfExists($file)

--- a/bin/phpunit-steward
+++ b/bin/phpunit-steward
@@ -1,0 +1,17 @@
+#!/usr/bin/env php
+<?php
+
+function requireIfExists($file)
+{
+    if (is_file($file)) {
+        return require_once $file;
+    }
+
+    return false;
+}
+
+requireIfExists(__DIR__ . '/../vendor/autoload.php') || requireIfExists(__DIR__ . '/../../../autoload.php');
+
+date_default_timezone_set('Europe/Prague');
+
+PHPUnit_TextUI_Command::main();

--- a/bin/steward
+++ b/bin/steward
@@ -14,14 +14,21 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 function requireIfExists($file)
 {
-    if (file_exists($file)) {
+    if (is_file($file)) {
         return require_once $file;
     }
+
+    return false;
 }
 
-if (!requireIfExists(__DIR__ . '/../vendor/autoload.php') // when used directly
-    && !requireIfExists(__DIR__ . '/../../../autoload.php') // when installed as dependency
-) {
+$installedAsDependency = null;
+if (requireIfExists(__DIR__ . '/../vendor/autoload.php')) { // used directly as the main package
+    $installedAsDependency = false;
+} elseif (requireIfExists(__DIR__ . '/../../../autoload.php')) { // installed with Composer as a dependency
+    $installedAsDependency = true;
+}
+
+if ($installedAsDependency === null) {
     die(
         'You must set up the project dependencies, run the following commands:' . PHP_EOL .
         'curl -sS https://getcomposer.org/installer | php' . PHP_EOL .
@@ -29,9 +36,9 @@ if (!requireIfExists(__DIR__ . '/../vendor/autoload.php') // when used directly
     );
 }
 
-if (strpos(__DIR__, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) !== false) { // when installed as dependency
+if ($installedAsDependency) {
     define('STEWARD_BASE_DIR', realpath(__DIR__ . '/../../../..'));
-} else { // when used directly
+} else {
     define('STEWARD_BASE_DIR', realpath(__DIR__ . '/..'));
 }
 

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
@@ -15,7 +15,7 @@ Testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" is prepar
 %aStarting execution of testcases
 -------------------------------
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" started with command:
-'%s/vendor/bin/phpunit' '--log-junit=%s/logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-SimpleTest.xml' '--configuration=%s/phpunit.xml' '%s/SimpleTest.php'%A
+'%s/steward/bin/phpunit-steward' '--log-junit=%s/logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-SimpleTest.xml' '--configuration=%s/phpunit.xml' '%s/SimpleTest.php'%A
 [%s] Waiting (running: 1, queued: 1, done: 0)%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Registering test results publisher "Lmc\Steward\Publisher\XmlPublisher"%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s]: Initializing "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest::testWebpage"%A
@@ -38,7 +38,7 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> OK (1 test, 1 asser
 [%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed, time: %f sec)%A
 [%s] Unqueing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" started with command:
-'%s/vendor/bin/phpunit' '--log-junit=%s/logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-DependantTest.xml' '--configuration=%s/phpunit.xml' '%s/DependantTest.php'
+'%s/steward/bin/phpunit-steward' '--log-junit=%s/logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-DependantTest.xml' '--configuration=%s/phpunit.xml' '%s/DependantTest.php'
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Registering test results publisher "Lmc\Steward\Publisher\XmlPublisher"%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: Initializing "firefox" WebDriver for "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar"%A
 %a[%s]: Starting execution of test Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest::testFooBar%aLmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s]: [WebDriver] Executing command "setWindowSize" with params {"width":1280,"height":1024,":windowHandle":"current"}

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -198,7 +198,7 @@ class ProcessSetCreator
             ->setEnv('FIXTURES_DIR', $this->config[ConfigOptions::FIXTURES_DIR])
             ->setEnv('LOGS_DIR', $this->config[ConfigOptions::LOGS_DIR])
             ->setEnv('DEBUG', $this->output->isDebug() ? '1' : '0')
-            ->setPrefix($phpunitExecutable)
+            ->setPrefix([PHP_BINARY, $phpunitExecutable])
             ->setArguments(array_merge($processEvent->getArgs(), [$fileName]))
             ->setTimeout(3600); // 1 hour timeout to end possibly stuck processes
 

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -187,6 +187,8 @@ class ProcessSetCreator
         $capabilities = (new KeyValueCapabilityOptionsParser())
             ->parse($this->input->getOption(RunCommand::OPTION_CAPABILITY));
 
+        $phpunitExecutable = realpath(__DIR__ . '/../../bin/phpunit-steward');
+
         $processBuilder
             ->setEnv('BROWSER_NAME', $this->input->getArgument(RunCommand::ARGUMENT_BROWSER))
             ->setEnv('ENV', mb_strtolower($this->input->getArgument(RunCommand::ARGUMENT_ENVIRONMENT)))
@@ -196,7 +198,7 @@ class ProcessSetCreator
             ->setEnv('FIXTURES_DIR', $this->config[ConfigOptions::FIXTURES_DIR])
             ->setEnv('LOGS_DIR', $this->config[ConfigOptions::LOGS_DIR])
             ->setEnv('DEBUG', $this->output->isDebug() ? '1' : '0')
-            ->setPrefix(STEWARD_BASE_DIR . '/vendor/bin/phpunit')
+            ->setPrefix($phpunitExecutable)
             ->setArguments(array_merge($processEvent->getArgs(), [$fileName]))
             ->setTimeout(3600); // 1 hour timeout to end possibly stuck processes
 


### PR DESCRIPTION
One could have defined [custom directory](https://getcomposer.org/doc/06-config.md#vendor-dir) to install composer dependencies. However, this will break detection of default path to tests, logs. etc. and also path to phpunit binary executable.

This should fix it all 💪. Hopefully 😵.

(Replaces #156)

