### PR TITLE
Make tests compatible with PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 7
   - 7.1
+  - 7.2
 
 matrix:
   include:

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -359,6 +359,9 @@ class RunCommandTest extends TestCase
         $processSetMock->expects($this->any())
             ->method('count')
             ->willReturn(333);
+        $processSetMock->expects($this->any())
+            ->method('get')
+            ->willReturn([]);
 
         $creatorMock = $this->getMockBuilder(ProcessSetCreator::class)
             ->disableOriginalConstructor()

--- a/src-tests/Selenium/CapabilitiesResolverTest.php
+++ b/src-tests/Selenium/CapabilitiesResolverTest.php
@@ -21,6 +21,7 @@ class CapabilitiesResolverTest extends TestCase
     /**
      * @dataProvider provideBrowsers
      * @param string $browser
+     * @requires extension zip
      */
     public function testShouldResolveBasicDesiredCapabilities($browser, callable $extraCallback = null)
     {
@@ -70,6 +71,9 @@ class CapabilitiesResolverTest extends TestCase
         ];
     }
 
+    /**
+     * @requires extension zip
+     */
     public function testShouldResolveExtraDesiredCapabilitiesOnCiServer()
     {
         /** @var AbstractTestCase $test */


### PR DESCRIPTION
However code coverage still throws lots of errors, caused by https://github.com/sebastianbergmann/php-code-coverage/issues/551 .