### PR TITLE
Require Symfony 4 components, BC break RunTestsProcessEvent

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,7 +12,6 @@ return PhpCsFixer\Config::create()
         'cast_spaces' => true,
         'concat_space' => ['spacing' => 'one'],
         'function_typehint_space' => true,
-        'linebreak_after_opening_tag' => true,
         'lowercase_cast' => true,
         'mb_str_functions' => true,
         'method_separation' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Unreleased
 ### Changed
-- Require PHP 7.1+
+- Require PHP 7.1+ and Symfony 4 components
+- `RunTestsProcessEvent` (dispatched from `run` command when initializing PHPUnit processes) now contains array of environment variables instead of ProcessBuilder. Use `setEnvironmentVars()` method to change the variables passed to the process.
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,14 @@
         "ext-zip": "*",
         "ext-curl": "*",
         "phpunit/phpunit": "^5.7.11",
-        "symfony/console": "^3.3.0",
-        "symfony/process": "^3.2.0",
-        "symfony/finder": "~3.0",
-        "symfony/event-dispatcher": "~3.0",
-        "symfony/filesystem": "~3.0",
-        "symfony/stopwatch": "^3.0",
+        "symfony/console": "^4.0",
+        "symfony/process": "^4.0",
+        "symfony/finder": "^4.0",
+        "symfony/event-dispatcher": "^4.0",
+        "symfony/filesystem": "^4.0",
+        "symfony/stopwatch": "^4.0",
+        "symfony/yaml": "^4.0",
+        "symfony/options-resolver": "^4.0",
         "nette/reflection": "^2.4.2",
         "facebook/webdriver": "^1.4.0",
         "clue/graph": "~0.9.0",
@@ -43,16 +45,14 @@
         "florianwolters/component-util-singleton": "0.3.2",
         "doctrine/inflector": "~1.0",
         "beberlei/assert": "^2.7",
-        "ondram/ci-detector": "^3.0",
-        "symfony/yaml": "^3.2",
-        "symfony/options-resolver": "^3.2"
+        "ondram/ci-detector": "^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1",
         "php-mock/php-mock-phpunit": "~1.0",
         "php-coveralls/php-coveralls": "^2.0@dev",
         "friendsofphp/php-cs-fixer": "^2.0",
-        "symfony/var-dumper": "^3.2"
+        "symfony/var-dumper": "^4.0"
     },
     "suggest": {
         "ext-posix": "For colored output",

--- a/src-tests/Console/Event/RunTestsProcessEventTest.php
+++ b/src-tests/Console/Event/RunTestsProcessEventTest.php
@@ -1,11 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Lmc\Steward\Console\Event;
 
 use Lmc\Steward\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\ProcessBuilder;
 
 class RunTestsProcessEventTest extends ExtendedConsoleEventTest
 {
@@ -15,10 +14,8 @@ class RunTestsProcessEventTest extends ExtendedConsoleEventTest
     protected $outputMock;
     /** @var Command|\PHPUnit_Framework_MockObject_MockObject */
     protected $commandMock;
-    /** @var ProcessBuilder */
-    protected $processBuilder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->commandMock = $this->getMockBuilder(Command::class)
             ->disableOriginalConstructor()
@@ -31,36 +28,40 @@ class RunTestsProcessEventTest extends ExtendedConsoleEventTest
         $this->outputMock = $this->getMockBuilder(OutputInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-
-        $this->processBuilder = new ProcessBuilder();
     }
 
-    public function testShouldGetPropertiesPassedInConstructor()
+    public function testShouldGetPropertiesPassedInConstructor(): void
     {
         $event = new RunTestsProcessEvent(
             $this->commandMock,
             $this->inputMock,
             $this->outputMock,
-            $this->processBuilder,
+            ['env1' => 'foo', 'env2' => 'bar'],
             ['foo', 'bar']
         );
 
         $this->assertSame($this->commandMock, $event->getCommand());
         $this->assertSame($this->inputMock, $event->getInput());
         $this->assertSame($this->outputMock, $event->getOutput());
-        $this->assertSame($this->processBuilder, $event->getProcessBuilder());
+        $this->assertSame(['env1' => 'foo', 'env2' => 'bar'], $event->getEnvironmentVars());
         $this->assertSame(['foo', 'bar'], $event->getArgs());
     }
 
-    public function testShouldAllowToOverwriteArgsArray()
+    public function testShouldAllowToOverwriteEnvironmentVariablesAndArgsArray(): void
     {
         $event = new RunTestsProcessEvent(
             $this->commandMock,
             $this->inputMock,
             $this->outputMock,
-            $this->processBuilder,
+            ['env1' => 'foo', 'env2' => 'bar'],
             ['foo', 'bar']
         );
+
+        // Set custom env, overwrite those from constructor
+        $event->setEnvironmentVars(['env3' => 'bak', 'env4' => 'bat']);
+
+        // Check they are retrieved using the getter
+        $this->assertSame(['env3' => 'bak', 'env4' => 'bat'], $event->getEnvironmentVars());
 
         // Set custom args, overwrite those from constructor
         $event->setArgs(['baz', 'ban']);

--- a/src/Console/Event/RunTestsProcessEvent.php
+++ b/src/Console/Event/RunTestsProcessEvent.php
@@ -1,11 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Lmc\Steward\Console\Event;
 
 use Lmc\Steward\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Event dispatched from `run` command when initializing PHPUnit Processes.
@@ -13,8 +12,8 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class RunTestsProcessEvent extends ExtendedConsoleEvent
 {
-    /** @var ProcessBuilder */
-    protected $processBuilder;
+    /** @var array */
+    protected $environmentVars;
     /** @var array */
     protected $args;
 
@@ -22,43 +21,38 @@ class RunTestsProcessEvent extends ExtendedConsoleEvent
      * @param Command $command
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @param ProcessBuilder $processBuilder
+     * @param array $environmentVars Environment variables passed to the process
      * @param array $args Arguments passed to the process
      */
     public function __construct(
         Command $command,
         InputInterface $input,
         OutputInterface $output,
-        ProcessBuilder $processBuilder,
+        array $environmentVars,
         array $args
     ) {
         parent::__construct($command, $input, $output);
 
-        $this->processBuilder = $processBuilder;
+        $this->environmentVars = $environmentVars;
         $this->args = $args;
     }
 
-    /**
-     * @return ProcessBuilder
-     */
-    public function getProcessBuilder()
+    public function getEnvironmentVars(): array
     {
-        return $this->processBuilder;
+        return $this->environmentVars;
     }
 
-    /**
-     * @return array
-     */
-    public function getArgs()
+    public function setEnvironmentVars(array $environmentVars)
+    {
+        $this->environmentVars = $environmentVars;
+    }
+
+    public function getArgs(): array
     {
         return $this->args;
     }
 
-    /**
-     * Allow to update args array
-     * @param array $args
-     */
-    public function setArgs($args)
+    public function setArgs(array $args)
     {
         $this->args = $args;
     }

--- a/src/Console/EventListener/XdebugListener.php
+++ b/src/Console/EventListener/XdebugListener.php
@@ -41,7 +41,7 @@ class XdebugListener implements EventSubscriberInterface
      */
     public function onCommandConfigure(BasicConsoleEvent $event)
     {
-        if ($event->getCommand()->getName() != 'run') {
+        if ($event->getCommand()->getName() !== 'run') {
             return;
         }
 
@@ -103,8 +103,9 @@ class XdebugListener implements EventSubscriberInterface
     public function onCommandRunTestsProcess(RunTestsProcessEvent $event)
     {
         if ($this->xdebugIdeKey) {
-            $event->getProcessBuilder()
-                ->setEnv('XDEBUG_CONFIG', 'idekey=' . $this->xdebugIdeKey);
+            $env = $event->getEnvironmentVars();
+            $env['XDEBUG_CONFIG'] = 'idekey=' . $this->xdebugIdeKey;
+            $event->setEnvironmentVars($env);
         }
     }
 


### PR DESCRIPTION
ProcessBuilder was removed from Symfony 4. RunTestsProcessEvent was changed to contains environmen variables instead of ProcessBuilder instance.