### PR TITLE
Allow to disable setting default browser size on test startup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Require PHP 7.1+ and Symfony 4 components
 - `RunTestsProcessEvent` (dispatched from `run` command when initializing PHPUnit processes) now contains array of environment variables instead of ProcessBuilder. Use `setEnvironmentVars()` method to change the variables passed to the process.
+- Default browser size is now defined using class constants instead of class variables. To override the default, instead of `public static $browserWidth = ...;` use `public const BROWSER_WIDTH = ...;`.
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Require PHP 7.1+ and Symfony 4 components
 - `RunTestsProcessEvent` (dispatched from `run` command when initializing PHPUnit processes) now contains array of environment variables instead of ProcessBuilder. Use `setEnvironmentVars()` method to change the variables passed to the process.
 - Default browser size is now defined using class constants instead of class variables. To override the default, instead of `public static $browserWidth = ...;` use `public const BROWSER_WIDTH = ...;`.
+- When test class constants defining default browser width (`BROWSER_WIDTH`) or height (`BROWSER_HEIGHT`) is set to `null`, no default browser window size will be set on test startup.
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -26,7 +26,7 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
     {
         $this->log('Starting execution of test ' . get_called_class() . '::' . $this->getName());
 
-        if ($this->wd instanceof RemoteWebDriver) {
+        if ($this->wd instanceof RemoteWebDriver && static::BROWSER_WIDTH !== null && static::BROWSER_HEIGHT !== null) {
             $this->wd->manage()->window()->setSize(
                 new WebDriverDimension(static::BROWSER_WIDTH, static::BROWSER_HEIGHT)
             );

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -14,11 +14,10 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
 {
     use SyntaxSugarTrait;
 
-    /** @var int Width of browser window */
-    public static $browserWidth = 1280;
-
-    /** @var int Height of browser window */
-    public static $browserHeight = 1024;
+    /** @var int|null Default width of browser window. Use null to disable setting default window size on startup. */
+    public const BROWSER_WIDTH = 1280;
+    /** @var int|null Default height of browser window. Use null to disable setting default window size on startup. */
+    public const BROWSER_HEIGHT = 1024;
 
     /** @var string Log appended to output of this test */
     protected $appendedTestLog;
@@ -29,7 +28,7 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
 
         if ($this->wd instanceof RemoteWebDriver) {
             $this->wd->manage()->window()->setSize(
-                new WebDriverDimension(static::$browserWidth, static::$browserHeight)
+                new WebDriverDimension(static::BROWSER_WIDTH, static::BROWSER_HEIGHT)
             );
         }
     }


### PR DESCRIPTION
Also use constants instead of class variables to emphasize its value cannot be changed on runtime.