### PR TITLE
Remove no longer used configuration of fixtures directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - Instead of `TestUtils::getFixturePath()` use `Facebook\WebDriver\Remote\FileDetector` instead.
     - Instead of `TestUtils::sleep()` use `AbstractTestCase::sleep()` method instead.
 - `getConfig()` method of ConfigProvider. Instead call the property directly on instance of the ConfigProvider.
+- `--fixtures-dir` option of the `run` command, `fixtures_dir` option of configuration file and `ConfigProvider->fixturesDir` variable. They were deprecated in version 2.1.0 and no longer used since.
 
 ## 2.3.2 - 2017-12-02
 ### Changed

--- a/src-tests/ConfigHelper.php
+++ b/src-tests/ConfigHelper.php
@@ -30,7 +30,6 @@ class ConfigHelper
             'SERVER_URL' => 'http://server.tld:4444',
             'CAPABILITY' => '', // intentionally empty, used by ConfigProviderTest::testShouldDetectEmptyConfigOption
             'CAPABILITIES_RESOLVER' => '',
-            'FIXTURES_DIR' => __DIR__,
             'LOGS_DIR' => __DIR__,
             'DEBUG' => 0,
         ];

--- a/src-tests/Console/Command/Fixtures/FailingTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/FailingTests/expected-very-verbose-output.txt
@@ -1,7 +1,6 @@
 Steward UNKNOWN is running the tests...%S
 Browser: firefox
 Environment: staging
-Base path to fixtures results: %s/tests
 Path to logs: %s/logs
 Ignore delays: no
 Selenium server (hub) url: %s, trying connection...OK

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
@@ -1,7 +1,6 @@
 Steward UNKNOWN is running the tests...%S
 Browser: firefox
 Environment: staging
-Base path to fixtures results: %s/tests
 Path to logs: %s/logs
 Ignore delays: no
 Selenium server (hub) url: %s, trying connection...OK

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
@@ -1,7 +1,6 @@
 Steward UNKNOWN is running the tests...%S
 Browser: firefox
 Environment: staging
-Base path to fixtures results: %s/tests
 Path to logs: %s/logs
 Ignore delays: no
 Selenium server (hub) url: %s, trying connection...OK

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -102,7 +102,6 @@ class RunCommandTest extends TestCase
         return [
             ['tests-dir', 'Path to directory with tests "/not/accessible" does not exist'],
             ['logs-dir', 'Path to directory with logs "/not/accessible" does not exist'],
-            ['fixtures-dir', 'Base path to directory with fixture files "/not/accessible" does not exist'],
         ];
     }
 
@@ -118,14 +117,12 @@ class RunCommandTest extends TestCase
                 'browser' => 'firefox',
                 '--tests-dir' => __DIR__ . '/Fixtures/DummyTests',
                 '--logs-dir' => __DIR__ . '/Fixtures/logs',
-                '--fixtures-dir' => __DIR__ . '/Fixtures/tests',
                 '--pattern' => 'NotExisting.foo', // so the test stops execution
             ],
             ['verbosity' => OutputInterface::VERBOSITY_DEBUG]
         );
 
         $output = $this->tester->getDisplay();
-        $this->assertContains('Base path to fixtures results: ' . realpath(__DIR__) . '/Fixtures/tests', $output);
         $this->assertContains('Path to logs: ' . realpath(__DIR__) . '/Fixtures/logs', $output);
         $this->assertContains(' - in directory "' . realpath(__DIR__) . '/Fixtures/DummyTests"', $output);
         $this->assertSame(1, $this->tester->getStatusCode());
@@ -156,7 +153,6 @@ class RunCommandTest extends TestCase
                 'environment' => 'prod',
                 'browser' => $browserName,
                 '--tests-dir' => __DIR__ . '/Fixtures/tests',
-                '--fixtures-dir' => __DIR__,
             ],
             ['verbosity' => OutputInterface::VERBOSITY_DEBUG]
         );

--- a/src-tests/Console/Configuration/ConfigResolverTest.php
+++ b/src-tests/Console/Configuration/ConfigResolverTest.php
@@ -38,7 +38,6 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertStringEndsWith('steward' . DIRECTORY_SEPARATOR . 'tests', $config[ConfigOptions::TESTS_DIR]);
         $this->assertStringEndsWith('steward' . DIRECTORY_SEPARATOR . 'logs', $config[ConfigOptions::LOGS_DIR]);
-        $this->assertStringEndsWith('steward' . DIRECTORY_SEPARATOR . 'tests', $config[ConfigOptions::FIXTURES_DIR]);
     }
 
     public function testShouldResolveDefaultOptionsSpecificForCleanCommand()
@@ -57,7 +56,6 @@ class ConfigResolverTest extends \PHPUnit_Framework_TestCase
             $config[ConfigOptions::LOGS_DIR]
         );
         $this->assertFalse(isset($config[ConfigOptions::TESTS_DIR]));
-        $this->assertFalse(isset($config[ConfigOptions::FIXTURES_DIR]));
     }
 
     /**

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -71,7 +71,6 @@ class ProcessSetCreatorTest extends TestCase
             $this->publisherMock,
             [
                 ConfigOptions::LOGS_DIR => '/foo/bar/logs',
-                ConfigOptions::FIXTURES_DIR => '/foo/bar/fixtures',
                 ConfigOptions::CAPABILITIES_RESOLVER => '',
             ]
         );
@@ -120,7 +119,6 @@ class ProcessSetCreatorTest extends TestCase
             'BROWSER_NAME' => 'firefox',
             'ENV' => 'staging',
             'SERVER_URL' => $definition->getOption(RunCommand::OPTION_SERVER_URL)->getDefault(),
-            'FIXTURES_DIR' => '/foo/bar/fixtures',
             'LOGS_DIR' => '/foo/bar/logs',
         ];
         $this->assertArraySubset($expectedEnv, $testEnv);
@@ -271,9 +269,7 @@ class ProcessSetCreatorTest extends TestCase
                 'staging',
                 'chrome',
                 '--' . RunCommand::OPTION_SERVER_URL . '=http://foo.bar:1337',
-                '--' . RunCommand::OPTION_FIXTURES_DIR . '=' . realpath(__DIR__ . '/Fixtures/custom-fixtures-dir/'),
                 '--' . RunCommand::OPTION_SERVER_URL . '=' . 'http://foo.bar:1337',
-                '--' . RunCommand::OPTION_FIXTURES_DIR . '=' . realpath(__DIR__ . '/Fixtures/custom-fixtures-dir/'),
                 '--' . RunCommand::OPTION_LOGS_DIR . '=' . realpath(__DIR__ . '/Fixtures/custom-logs-dir/'),
                 '--' . RunCommand::OPTION_CAPABILITY . '=webdriver.log.file:/foo/bar.log',
                 '--' . RunCommand::OPTION_CAPABILITY . '=whitespaced:OS X 10.8',
@@ -305,7 +301,6 @@ class ProcessSetCreatorTest extends TestCase
                 'BROWSER_NAME' => 'chrome',
                 'ENV' => 'staging',
                 'SERVER_URL' => 'http://foo.bar:1337',
-                'FIXTURES_DIR' => realpath(__DIR__ . '/Fixtures/custom-fixtures-dir/'),
                 'LOGS_DIR' => realpath(__DIR__ . '/Fixtures/custom-logs-dir/'),
                 'CAPABILITY' => '{"webdriver.log.file":"\/foo\/bar.log","whitespaced":"OS X 10.8",'
                     . '"webdriver.foo":false,"version":"14.14393"}',

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -15,7 +15,6 @@ use FlorianWolters\Component\Util\Singleton\SingletonTrait;
  * @property-read string $serverUrl
  * @property-read string $capability
  * @property-read string $capabilitiesResolver
- * @property-read string $fixturesDir
  * @property-read string $logsDir
  * @property-read string $debug
  */
@@ -114,7 +113,6 @@ class ConfigProvider
             'SERVER_URL',
             'CAPABILITY',
             'CAPABILITIES_RESOLVER',
-            'FIXTURES_DIR',
             'LOGS_DIR',
             'DEBUG',
         ];

--- a/src/Console/Command/RunCommand.php
+++ b/src/Console/Command/RunCommand.php
@@ -48,7 +48,6 @@ class RunCommand extends Command
     const OPTION_SERVER_URL = 'server-url';
     const OPTION_CAPABILITY = 'capability';
     const OPTION_TESTS_DIR = 'tests-dir';
-    const OPTION_FIXTURES_DIR = 'fixtures-dir';
     const OPTION_LOGS_DIR = 'logs-dir';
     const OPTION_PATTERN = 'pattern';
     const OPTION_GROUP = 'group';
@@ -108,13 +107,6 @@ class RunCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Path to directory with tests',
-                STEWARD_BASE_DIR . DIRECTORY_SEPARATOR . 'tests'
-            )
-            ->addOption(
-                self::OPTION_FIXTURES_DIR,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Base path to directory with fixture files',
                 STEWARD_BASE_DIR . DIRECTORY_SEPARATOR . 'tests'
             )
             ->addOption(
@@ -221,9 +213,6 @@ class RunCommand extends Command
         );
 
         if ($output->isVeryVerbose()) {
-            $output->writeln(
-                sprintf('Base path to fixtures results: %s', $this->config[ConfigOptions::FIXTURES_DIR])
-            );
             $output->writeln(
                 sprintf('Path to logs: %s', $this->config[ConfigOptions::LOGS_DIR])
             );

--- a/src/Console/Configuration/ConfigOptions.php
+++ b/src/Console/Configuration/ConfigOptions.php
@@ -10,7 +10,6 @@ final class ConfigOptions
     const CAPABILITIES_RESOLVER = 'capabilities_resolver';
     const TESTS_DIR = 'tests_dir';
     const LOGS_DIR = 'logs_dir';
-    const FIXTURES_DIR = 'fixtures_dir';
 
     private function __construct()
     {

--- a/src/Console/Configuration/ConfigResolver.php
+++ b/src/Console/Configuration/ConfigResolver.php
@@ -89,7 +89,7 @@ class ConfigResolver
     {
         $relevantDirOptionsForCommand = [];
 
-        foreach ([ConfigOptions::TESTS_DIR, ConfigOptions::LOGS_DIR, ConfigOptions::FIXTURES_DIR] as $dirOptionName) {
+        foreach ([ConfigOptions::TESTS_DIR, ConfigOptions::LOGS_DIR] as $dirOptionName) {
             $dirOptionName = str_replace('_', '-', $dirOptionName);
 
             if ($this->inputDefinition->hasOption($dirOptionName)) {

--- a/src/Console/Configuration/OptionsResolverConfigurator.php
+++ b/src/Console/Configuration/OptionsResolverConfigurator.php
@@ -63,7 +63,6 @@ class OptionsResolverConfigurator
         $dirs = [
             ConfigOptions::TESTS_DIR,
             ConfigOptions::LOGS_DIR,
-            ConfigOptions::FIXTURES_DIR,
         ];
 
         foreach ($dirs as $dirOption) {

--- a/src/Process/ProcessSetCreator.php
+++ b/src/Process/ProcessSetCreator.php
@@ -178,7 +178,6 @@ class ProcessSetCreator
             'CAPABILITY' => json_encode($capabilities),
             'CAPABILITIES_RESOLVER' => $this->config[ConfigOptions::CAPABILITIES_RESOLVER],
             'SERVER_URL' => $this->input->getOption(RunCommand::OPTION_SERVER_URL),
-            'FIXTURES_DIR' => $this->config[ConfigOptions::FIXTURES_DIR],
             'LOGS_DIR' => $this->config[ConfigOptions::LOGS_DIR],
             'DEBUG' => $this->output->isDebug() ? '1' : '0',
         ];


### PR DESCRIPTION
It was deprecated and replaced with direct use of `Facebook\WebDriver\Remote\FileDetector` since version 2.1.0. The option was kept only for backward compatibility reasons.