### PR TITLE
Don't hardcode timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `RunTestsProcessEvent` (dispatched from `run` command when initializing PHPUnit processes) now contains array of environment variables instead of ProcessBuilder. Use `setEnvironmentVars()` method to change the variables passed to the process.
 - Default browser size is now defined using class constants instead of class variables. To override the default, instead of `public static $browserWidth = ...;` use `public const BROWSER_WIDTH = ...;`.
 - When test class constants defining default browser width (`BROWSER_WIDTH`) or height (`BROWSER_HEIGHT`) is set to `null`, no default browser window size will be set on test startup.
+- Don't hardcode timezone to `Europe/Prague`. Timezone is now used based on your PHP settings ([date.timezone](http://php.net/manual/en/datetime.configuration.php#ini.date.timezone)).
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/bin/phpunit-steward
+++ b/bin/phpunit-steward
@@ -11,6 +11,4 @@ function requireIfExists($file)
 
 requireIfExists(__DIR__ . '/../vendor/autoload.php') || requireIfExists(__DIR__ . '/../../../autoload.php');
 
-date_default_timezone_set('Europe/Prague');
-
 PHPUnit_TextUI_Command::main();

--- a/bin/steward
+++ b/bin/steward
@@ -42,8 +42,6 @@ if ($installedAsDependency) {
     define('STEWARD_BASE_DIR', realpath(__DIR__ . '/..'));
 }
 
-date_default_timezone_set('Europe/Prague');
-
 $dispatcher = new EventDispatcher();
 $application = new Application('Steward', '3.0.0-DEV');
 $application->setDispatcher($dispatcher);

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -2,8 +2,6 @@
 
 // Bootstrap before each Testcase
 
-date_default_timezone_set('Europe/Prague');
-
 if (file_exists($autoload = __DIR__ . '/../vendor/autoload.php')) {
     require_once $autoload;
 } elseif (file_exists($autoload = __DIR__ . '/../../../autoload.php')) {


### PR DESCRIPTION
Not needed since PHP 7.0. User should set timezone by himself/herself.

http://php.net/manual/en/migration70.other-changes.php#migration70.other-changes.remove-date-timezone-warning

Fixes #183 