### PR TITLE
Fix --xdebug having effect only if passed as the last option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Remote server running in W3C-protocol mode (eg. Selenium v3.5.3+) was erroneously detected as BrowserStack cloud service.
+- `--xdebug` option did not have any effect unless passed as the last option.
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/src-tests/Console/EventListener/XdebugListenerTest.php
+++ b/src-tests/Console/EventListener/XdebugListenerTest.php
@@ -108,9 +108,19 @@ class XdebugListenerTest extends TestCase
     public function provideInput()
     {
         return [
-            'use default idekey when no specific value is passed' => ['run --xdebug', 'phpstorm'],
-            'use custom idekey passed as option' => ['run --xdebug=custom', 'custom'],
-            'do nothing if xdebug option not passed' => ['run', null],
+            'option not passed at all => no idekey' => ['run', null],
+            'option passed without custom value => default idekey' => ['run --xdebug', 'phpstorm'],
+            'option passed with empty custom value => no idekey' => ['run --xdebug=""', null],
+            'option passed without custom value => default idekey (combined with another option)' => [
+                'run --xdebug --no-exit',
+                'phpstorm',
+            ],
+            'custom idekey passed' => ['run --xdebug=custom', 'custom'],
+            'custom idekey passed (combined with another option)' => ['run --xdebug=custom --no-exit', 'custom'],
+            'custom idekey passed (but with default value of idekey)' => [
+                'run --xdebug=' . XdebugListener::DEFAULT_VALUE,
+                'phpstorm',
+            ],
         ];
     }
 

--- a/src/Console/EventListener/XdebugListener.php
+++ b/src/Console/EventListener/XdebugListener.php
@@ -49,8 +49,8 @@ class XdebugListener implements EventSubscriberInterface
             self::OPTION_XDEBUG,
             null,
             InputOption::VALUE_OPTIONAL,
-            'Start Xdebug debugger on tests; use given IDE key. Default value is used only if empty option is passed.',
-            self::DEFAULT_VALUE
+            'Start Xdebug debugger on tests. Pass custom IDE key if needed for your IDE settings.',
+            ''
         );
     }
 
@@ -111,22 +111,24 @@ class XdebugListener implements EventSubscriberInterface
 
     /**
      * If --xdebug option was not passed at all, return null to not activate the feature.
-     * If the option was used without a value, use the default value.
-     * If the option was passed with custom value, use this value.
+     * If the option was used without a value, use the default value of idekey.
+     * If the option was passed with custom (not empty) value, use this value.
      *
      * @param InputInterface $input
      * @return string|null
      */
     protected function getIdeKeyFromInputOption(InputInterface $input)
     {
-        $unparsedOptionValue = $input->getParameterOption('--' . self::OPTION_XDEBUG);
+        $optionValue = $input->getOption(self::OPTION_XDEBUG);
 
-        if ($unparsedOptionValue === null) { // option was passed without value, use the default
+        if ($optionValue === null) { // no custom value was passed => use default
             return self::DEFAULT_VALUE;
-        } elseif ($unparsedOptionValue !== false) { // option was passed with value, use the value
-            return $input->getOption(self::OPTION_XDEBUG);
         }
 
-        return null;
+        if ($optionValue === '') { // empty value was passed => do not enable the feature
+            return null;
+        }
+
+        return $optionValue;
     }
 }


### PR DESCRIPTION
Fixes #165. Caused by changes made in #145 . 

Now we properly utilize the new behavior of symfony/console, available since Symfony 3.3 (https://github.com/symfony/symfony/pull/21228)

The Steward behavior now is (and should be even before):
```
$ steward run staging firefox # => xdebug debugging not enabled

$ steward run staging firefox --xdebug # => xdebug connects using IDE key "phpstorm"

$ steward run staging firefox --xdebug -vvv # => same as previous, but wasn't working before

$ steward run staging firefox --xdebug=netbeans-xdebug # => xdebug connects using custom IDE key "netbeans-xdebug"
```