### PR TITLE
Do not report tests without an assertion as risky

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -3,6 +3,7 @@
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.4/phpunit.xsd"
     bootstrap="bootstrap.php"
     backupGlobals="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
 >
     <listeners>
         <listener class="Lmc\Steward\Listener\TestStartLogListener"/>


### PR DESCRIPTION
PHPUnit 6 [by default](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0#backwards-compatibility-issues) reports tests without an assertion as risky. However, it is common practice to have seed tests creating some default data (ie. without an assertion) or tests which depends on expected conditions (instead of assertions), so this behavior will report many false positives.