### PR TITLE
Fix install command to properly detect latest released Selenium version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Fixed
+- Selenium server releases were incorrectly parsed, meaning `steward install` command will detect version 3.9.1 as the latest one (even though there are already released newer versions of Selenium server).
 
 ## 2.3.2 - 2017-12-02
 ### Changed

--- a/src/Selenium/Downloader.php
+++ b/src/Selenium/Downloader.php
@@ -42,14 +42,23 @@ class Downloader
         }
 
         $releases = $xml->xpath('//*[text()[contains(.,"selenium-server-standalone")]]');
-        $lastRelease = end($releases); // something like "2.42/selenium-server-standalone-2.42.2.jar"
+        $availableVersions = [];
+        foreach ($releases as $release) {
+            $parsedVersion = preg_replace('/.*standalone-(.+)\.jar/', '$1', $release);
+            if ((string) $release === $parsedVersion) { // regexp did not match
+                continue;
+            }
 
-        $lastVersion = preg_replace('/.*standalone-(.*)\.jar/', '$1', $lastRelease);
-        if ($lastRelease == $lastVersion) { // regexp not matched
+            $availableVersions[] = $parsedVersion;
+        }
+
+        if (!$availableVersions) {
             return null;
         }
 
-        return $lastVersion;
+        natcasesort($availableVersions);
+
+        return end($availableVersions);
     }
 
     /**


### PR DESCRIPTION
This is hotfix backport of similar bugfix, which will be part of 3.0 release (and master branch). This PR targets 2.3 branch and will be part of probably the the last 2.x release (2.3.3).

Because the Selenium storage does not order released version naturally (ie. 3.1.0, 3.10.0, 3.2.0 etc.), we must do it ourselves. Otherwise version 3.9.1 would keep installing forever (or at least until 3.99 is released :upside_down_face: ).