### PR TITLE
Update php-mock-phpunit and namespaced PHPUnit MockObjects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ext-filter": "*",
         "ext-SimpleXML": "*",
         "ext-libxml": "*",
-        "phpunit/phpunit": "^6.4",
+        "phpunit/phpunit": "^6.5",
         "symfony/console": "^4.0",
         "symfony/process": "^4.0 !=4.0.2",
         "symfony/finder": "^4.0",
@@ -55,7 +55,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1",
-        "php-mock/php-mock-phpunit": "^2.0.1",
+        "php-mock/php-mock-phpunit": "^2.1.0",
         "phpunit/php-code-coverage": "^5.2.3",
         "php-coveralls/php-coveralls": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,11 +4,11 @@ parameters:
 		- '#Constructor of class .+ImplementsCapabilitiesResolverInterface has an unused parameter \$config#'
 		- '#Lmc\\Steward\\ConfigProviderHelper::__construct\(\) does not call parent constructor from Lmc\\Steward\\ConfigProvider#'
 		- '#Constructor of class Lmc\\Steward\\Selenium\\Fixtures\\CapabilitiesResolverFixture has an unused parameter \$config#'
-		- '#Access to an undefined property PHPUnit_Framework_MockObject_MockObject#'
-		- '#Call to an undefined method PHPUnit_Framework_MockObject_MockObject::setCommandExecutor\(\)#'
+		- '#Access to an undefined property PHPUnit\\Framework\\MockObject\\MockObject#'
+		- '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::setCommandExecutor\(\)#'
 		- '#Call to an undefined method Lmc\\Steward\\Component\\Fixtures\\MockComponent::notExisting\(\)#'
-		- "#but returns PHPUnit_Framework_MockObject_MockObject#"
-		- "#does not accept PHPUnit_Framework_MockObject_MockObject#"
+		- "#but returns PHPUnit\\\\Framework\\\\MockObject\\\\MockObject#"
+		- "#does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject#"
 		- "#Property Lmc\\\\Steward\\\\Test\\\\AbstractTestCase::\\$wd \\(Facebook\\\\WebDriver\\\\Remote\\\\RemoteWebDriver\\) does not accept Lmc\\\\Steward\\\\WebDriver\\\\NullWebDriver#"
 	excludes_analyse:
 		- '%rootDir%/../../../../src-tests/Process/Fixtures/InvalidTests/WrongClassTest.php'

--- a/src-tests/Console/Command/CleanCommandTest.php
+++ b/src-tests/Console/Command/CleanCommandTest.php
@@ -4,6 +4,7 @@ namespace Lmc\Steward\Console\Command;
 
 use Assert\InvalidArgumentException;
 use Lmc\Steward\Console\Application;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -47,7 +48,7 @@ class CleanCommandTest extends TestCase
 
     public function testShouldCreateLogsDirectoryIfDefaultPathIsUsed(): void
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|Filesystem $filesystemMock */
+        /** @var MockObject|Filesystem $filesystemMock */
         $filesystemMock = $this->getMockBuilder(Filesystem::class)
             ->setMethods(['exists', 'mkdir'])
             ->getMock();

--- a/src-tests/Console/Command/GenerateTimelineCommandTest.php
+++ b/src-tests/Console/Command/GenerateTimelineCommandTest.php
@@ -3,6 +3,7 @@
 namespace Lmc\Steward\Console\Command;
 
 use Lmc\Steward\Console\Application;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -45,7 +46,7 @@ class GenerateTimelineCommandTest extends TestCase
 
     public function testShouldOutputHtmlFileWithJsonData(): void
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|Filesystem $filesystemMock */
+        /** @var MockObject|Filesystem $filesystemMock */
         $filesystemMock = $this->createMock(Filesystem::class);
         $filesystemMock->expects($this->once())
             ->method('dumpFile')

--- a/src-tests/Console/Command/InstallCommandTest.php
+++ b/src-tests/Console/Command/InstallCommandTest.php
@@ -8,6 +8,7 @@ use Lmc\Steward\Console\Event\BasicConsoleEvent;
 use Lmc\Steward\Console\Event\ExtendedConsoleEvent;
 use Lmc\Steward\Selenium\Downloader;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -259,9 +260,9 @@ class InstallCommandTest extends TestCase
     /**
      * Get Downloader mock mocking isAlreadyDownloaded and download method to act like file is being downloaded
      * @param int|bool $expectedFileSize
-     * @return Downloader|\PHPUnit_Framework_MockObject_MockObject $downloaderMock
+     * @return Downloader|MockObject $downloaderMock
      */
-    protected function getDownloadMock($expectedFileSize = 123): \PHPUnit_Framework_MockObject_MockObject
+    protected function getDownloadMock($expectedFileSize = 123): MockObject
     {
         $downloaderMock = $this->getMockBuilder(Downloader::class)
             ->setConstructorArgs([__DIR__ . '/Fixtures/vendor/bin'])

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -11,6 +11,7 @@ use Lmc\Steward\Process\ProcessSet;
 use Lmc\Steward\Process\ProcessSetCreator;
 use Lmc\Steward\Process\ProcessWrapper;
 use Lmc\Steward\Selenium\SeleniumServerAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -387,7 +388,7 @@ class RunCommandTest extends TestCase
     /**
      * Mock Selenium adapter as if connection is OK
      *
-     * @return SeleniumServerAdapter|\PHPUnit_Framework_MockObject_MockObject
+     * @return SeleniumServerAdapter|MockObject
      */
     protected function getSeleniumAdapterMock()
     {

--- a/src-tests/Console/Event/BasicConsoleEventTest.php
+++ b/src-tests/Console/Event/BasicConsoleEventTest.php
@@ -3,11 +3,12 @@
 namespace Lmc\Steward\Console\Event;
 
 use Lmc\Steward\Console\Command\Command;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class BasicConsoleEventTest extends TestCase
 {
-    /** @var Command|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var Command|MockObject */
     protected $commandMock;
 
     protected function setUp(): void

--- a/src-tests/Console/Event/ExtendedConsoleEventTest.php
+++ b/src-tests/Console/Event/ExtendedConsoleEventTest.php
@@ -3,16 +3,17 @@
 namespace Lmc\Steward\Console\Event;
 
 use Lmc\Steward\Console\Command\Command;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ExtendedConsoleEventTest extends BasicConsoleEventTest
 {
-    /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var InputInterface|MockObject */
     protected $inputMock;
-    /** @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var OutputInterface|MockObject */
     protected $outputMock;
-    /** @var Command|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var Command|MockObject */
     protected $commandMock;
 
     protected function setUp(): void

--- a/src-tests/Console/Event/RunTestsProcessEventTest.php
+++ b/src-tests/Console/Event/RunTestsProcessEventTest.php
@@ -3,16 +3,17 @@
 namespace Lmc\Steward\Console\Event;
 
 use Lmc\Steward\Console\Command\Command;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RunTestsProcessEventTest extends ExtendedConsoleEventTest
 {
-    /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var InputInterface|MockObject */
     protected $inputMock;
-    /** @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var OutputInterface|MockObject */
     protected $outputMock;
-    /** @var Command|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var Command|MockObject */
     protected $commandMock;
 
     protected function setUp(): void

--- a/src-tests/Listener/SnapshotListenerTest.php
+++ b/src-tests/Listener/SnapshotListenerTest.php
@@ -8,6 +8,7 @@ use Lmc\Steward\Test\AbstractTestCase;
 use Lmc\Steward\WebDriver\RemoteWebDriver;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\WarningTestCase;
 
@@ -44,7 +45,7 @@ class SnapshotListenerTest extends TestCase
             $testcaseName
         );
 
-        /** @var RemoteWebDriver|\PHPUnit_Framework_MockObject_MockObject $webDriver */
+        /** @var RemoteWebDriver|MockObject $webDriver */
         $webDriver = $this->createMock(RemoteWebDriver::class);
         $webDriver->expects($this->once())
             ->method('getCurrentURL')
@@ -153,7 +154,7 @@ class SnapshotListenerTest extends TestCase
         /** @var AbstractTestCase $test */
         $test = $this->getMockForAbstractClass(AbstractTestCase::class, ['testFooBar'], 'FooBarTest');
 
-        /** @var RemoteWebDriver|\PHPUnit_Framework_MockObject_MockObject $webDriver */
+        /** @var RemoteWebDriver|MockObject $webDriver */
         $webDriver = $this->createMock(RemoteWebDriver::class);
         $webDriver->expects($this->once())
             ->method('getCurrentURL')

--- a/src-tests/Listener/TestEndLogListenerTest.php
+++ b/src-tests/Listener/TestEndLogListenerTest.php
@@ -5,6 +5,7 @@ namespace Lmc\Steward\Listener;
 use Lmc\Steward\MockAbstractTestCaseWithNameTrait;
 use Lmc\Steward\Test\AbstractTestCase;
 use Lmc\Steward\Test\AbstractTestCaseTest;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class TestEndLogListenerTest extends TestCase
@@ -15,7 +16,7 @@ class TestEndLogListenerTest extends TestCase
     {
         $listener = new TestEndLogListener();
 
-        /** @var AbstractTestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
+        /** @var AbstractTestCase|MockObject $testCase */
         $testCase = $this->getAbstractTestCaseMock('MockedTest', 'testFooBar');
 
         $listener->endTest($testCase, 1);

--- a/src-tests/Listener/TestStatusListenerTest.php
+++ b/src-tests/Listener/TestStatusListenerTest.php
@@ -8,12 +8,13 @@ use Lmc\Steward\Listener\Fixtures\ExceptionThrowingPublisher;
 use Lmc\Steward\Publisher\SauceLabsPublisher;
 use Lmc\Steward\Publisher\TestingBotPublisher;
 use Lmc\Steward\Selenium\SeleniumServerAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\WarningTestCase;
 
 class TestStatusListenerTest extends TestCase
 {
-    /** @var SeleniumServerAdapter|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var SeleniumServerAdapter|MockObject */
     protected $seleniumAdapterMock;
 
     public function setUp(): void

--- a/src-tests/MockAbstractTestCaseWithNameTrait.php
+++ b/src-tests/MockAbstractTestCaseWithNameTrait.php
@@ -3,6 +3,8 @@
 namespace Lmc\Steward;
 
 use Lmc\Steward\Test\AbstractTestCase;
+use PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+use PHPUnit\Framework\MockObject\MockObject;
 
 trait MockAbstractTestCaseWithNameTrait
 {
@@ -18,18 +20,18 @@ trait MockAbstractTestCaseWithNameTrait
     );
 
     /**
-     * @return \PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount
+     * @return AnyInvokedCount
      */
     abstract public static function any();
 
     /**
-     * @return AbstractTestCase|\PHPUnit_Framework_MockObject_MockObject
+     * @return AbstractTestCase|MockObject
      */
     public function getAbstractTestCaseMock(
         string $testCaseName,
         string $testMethodName
-    ): \PHPUnit_Framework_MockObject_MockObject {
-        /** @var AbstractTestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
+    ): MockObject {
+        /** @var AbstractTestCase|MockObject $testCase */
         $testCase = $this->getMockForAbstractClass(
             AbstractTestCase::class,
             [],

--- a/src-tests/Process/ProcessSetCreatorTest.php
+++ b/src-tests/Process/ProcessSetCreatorTest.php
@@ -12,6 +12,7 @@ use Lmc\Steward\Process\Fixtures\DelayedTests\DelayedTest;
 use Lmc\Steward\Process\Fixtures\DelayedTests\FirstTest;
 use Lmc\Steward\Publisher\AbstractPublisher;
 use Lmc\Steward\Publisher\XmlPublisher;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ProcessSetCreatorTest extends TestCase
 {
-    /** @var EventDispatcher|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventDispatcher|MockObject */
     protected $dispatcherMock;
     /** @var RunCommand */
     protected $command;
@@ -37,7 +38,7 @@ class ProcessSetCreatorTest extends TestCase
     protected $bufferedOutput;
     /** @var ProcessSetCreator */
     protected $creator;
-    /** @var AbstractPublisher|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var AbstractPublisher|MockObject */
     protected $publisherMock;
 
     // Fully classified names of dummy tests

--- a/src-tests/Publisher/AbstractCloudPublisherTestCase.php
+++ b/src-tests/Publisher/AbstractCloudPublisherTestCase.php
@@ -6,6 +6,7 @@ use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Lmc\Steward\Test\AbstractTestCase;
 use Lmc\Steward\WebDriver\NullWebDriver;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractCloudPublisherTestCase extends TestCase
@@ -14,7 +15,7 @@ abstract class AbstractCloudPublisherTestCase extends TestCase
 
     /** @var AbstractCloudPublisher */
     protected $publisher;
-    /** @var \PHPUnit_Framework_MockObject_MockObject|AbstractTestCase */
+    /** @var MockObject|AbstractTestCase */
     protected $testInstanceMock;
 
     public function setUp(): void

--- a/src-tests/Publisher/XmlPublisherTest.php
+++ b/src-tests/Publisher/XmlPublisherTest.php
@@ -6,6 +6,7 @@ use Lmc\Steward\ConfigHelper;
 use Lmc\Steward\Test\AbstractTestCase;
 use Lmc\Steward\WebDriver\RemoteWebDriver;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ class XmlPublisherTest extends TestCase
 
     /** @var XmlPublisher */
     protected $publisher;
-    /** @var \PHPUnit_Framework_MockObject_MockObject|Test */
+    /** @var MockObject|Test */
     protected $testInstanceMock;
 
     public function setUp(): void

--- a/src-tests/Selenium/DownloaderTest.php
+++ b/src-tests/Selenium/DownloaderTest.php
@@ -4,6 +4,7 @@ namespace Lmc\Steward\Selenium;
 
 use Assert\InvalidArgumentException;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DownloaderTest extends TestCase
@@ -223,7 +224,7 @@ class DownloaderTest extends TestCase
     public function testShouldStoreDownloadedFileToExpectedLocation(): void
     {
         // Mock getFileUrl() method to return URL to fixtures on filesystem
-        /** @var Downloader|\PHPUnit_Framework_MockObject_MockObject $downloader */
+        /** @var Downloader|MockObject $downloader */
         $downloader = $this->getMockBuilder(Downloader::class)
             ->setConstructorArgs([__DIR__ . '/Fixtures'])
             ->setMethods(['getFileUrl'])
@@ -249,7 +250,7 @@ class DownloaderTest extends TestCase
 
     public function testShouldThrowExceptionIfFileCannotBeDownloaded(): void
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|Downloader $downloader */
+        /** @var MockObject|Downloader $downloader */
         $downloader = $this->getMockBuilder(Downloader::class)
             ->setConstructorArgs([__DIR__ . '/Fixtures'])
             ->setMethods(['getFileUrl'])
@@ -277,7 +278,7 @@ class DownloaderTest extends TestCase
             'Directory already exists, though it should be created only by the test'
         );
 
-        /** @var Downloader|\PHPUnit_Framework_MockObject_MockObject $downloader */
+        /** @var Downloader|MockObject $downloader */
         $downloader = $this->getMockBuilder(Downloader::class)
             ->setConstructorArgs([$expectedDirectory])
             ->setMethods(['getFileUrl'])

--- a/src-tests/Test/SyntaxSugarTraitTest.php
+++ b/src-tests/Test/SyntaxSugarTraitTest.php
@@ -7,6 +7,7 @@ use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use Facebook\WebDriver\WebDriverWait;
 use Lmc\Steward\WebDriver\RemoteWebDriver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SyntaxSugarTraitTest extends TestCase
@@ -31,7 +32,7 @@ class SyntaxSugarTraitTest extends TestCase
         string $expectedWebDriverByStrategy
     ): void {
         $wd = $this->trait->wd;
-        /** @var \PHPUnit_Framework_MockObject_MockObject $wd */
+        /** @var MockObject $wd */
         $wd->expects($this->once())
             ->method('findElement')
             ->with(WebDriverBy::$expectedWebDriverByStrategy('foobar'))
@@ -52,7 +53,7 @@ class SyntaxSugarTraitTest extends TestCase
         string $expectedWebDriverByStrategy
     ): void {
         $wd = $this->trait->wd;
-        /** @var \PHPUnit_Framework_MockObject_MockObject $wd */
+        /** @var MockObject $wd */
         $wd->expects($this->once())
             ->method('findElements')
             ->with(WebDriverBy::$expectedWebDriverByStrategy('foobar'))
@@ -93,7 +94,7 @@ class SyntaxSugarTraitTest extends TestCase
         string $method,
         bool $isElementMethod = true
     ): void {
-        /** @var WebDriverWait|\PHPUnit_Framework_MockObject_MockObject $waitMock */
+        /** @var WebDriverWait|MockObject $waitMock */
         $waitMock = $this->createMock(WebDriverWait::class);
 
         // Note the WebDriverExpectedCondition instances are not comparable (as they return callbacks), so we can

--- a/src-tests/WebDriver/RemoteWebDriverTest.php
+++ b/src-tests/WebDriver/RemoteWebDriverTest.php
@@ -5,11 +5,12 @@ namespace Lmc\Steward\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
 use Lmc\Steward\ConfigHelper;
 use Lmc\Steward\WebDriver\Fixtures\DummyCommandExecutor;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RemoteWebDriverTest extends TestCase
 {
-    /** @var RemoteWebDriver|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var RemoteWebDriver|MockObject */
     protected $driver;
 
     public function setUp(): void


### PR DESCRIPTION
https://github.com/php-mock/php-mock-phpunit finally supports PHPUnit 6.5/7.0, which includes namespaced MockObjects.