### PR TITLE
Backport visibility fix for setUp and tearDown methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
+### Fixed
+- Backport visibility fix of `setUp()` and `tearDown()` methods of AbstractTestCase (to eg. allow use of [lmc/coding-standard](https://github.com/lmc-eu/php-coding-standard/) in projects using Steward).
 
 ## 2.3.3 - 2018-03-12
 ### Fixed

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -30,7 +30,7 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
     /** @var string Log appended to output of this test */
     protected $appendedTestLog;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->log('Starting execution of test ' . get_called_class() . '::' . $this->getName());
 
@@ -43,7 +43,7 @@ abstract class AbstractTestCase extends AbstractTestCaseBase
         $this->utils = new TestUtils($this);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->log('Finished execution of test ' . get_called_class() . '::' . $this->getName());
     }


### PR DESCRIPTION
If you apply lmc/coding-standard, you are forced to use (proper) protected visibility of setUp and tearDown methods.

However, Steward 2.x uses public visibility, so you cannot change this to protected in your class, so you'd be forced to disable this codestyle check. 

This has already been fixed previously in master branch, so this is just a backport.