### PR TITLE
Add parallel limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 ### Added
+- `--parallel-limit` (`-l`) option of `run` command to allow limiting maximum number of tests being run simultaneously.
 - Show test duration in timeline tooltips.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ There is also a bunch of useful options for the `run` command:
 - `--server-url` - set different url of selenium server than the default (which is `http://localhost:4444/wd/hub`)
 - `--xdebug` - start Xdebug debugger on your tests. Allows you to debug tests from your IDE ([learn more about tests debugging][wiki-debugging] in our Wiki)
 - `--capability` - directly pass any extra capability to the Selenium WebDriver server ([see wiki][wiki-capabilities] for more information and examples)
+- `--parallel-limit` - limit number of testcases being executed in a parallel (default is 50)
 - `--help` - see all other options and default values
 - **adjust output levels:** by default, only the test results summary is printed to the output; the verbosity could be changed by the following:
     - `-v` - to instantly output name of failed test(s)

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
         "phpstan/phpstan-shim": "^0.10.5",
         "jakub-onderka/php-parallel-lint": "^1.0.0",
         "lmc/coding-standard": "^1.0.0",
-        "squizlabs/php_codesniffer": "^3.2.3",
         "phpstan/phpstan-phpunit": "^0.10.0"
     },
     "suggest": {

--- a/src-tests/Console/Command/Fixtures/FailingTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/FailingTests/expected-very-verbose-output.txt
@@ -3,6 +3,7 @@ Browser: chrome
 Environment: staging
 Path to logs: %s/logs
 Ignore delays: no
+Parallel limit: 50
 Selenium server (hub) url: %s, trying connection...OK
 Searching for testcases:
  - in directory %s/src-tests/Console/Command/Fixtures/FailingTests"

--- a/src-tests/Console/Command/Fixtures/ParallelTests/FirstTest.php
+++ b/src-tests/Console/Command/Fixtures/ParallelTests/FirstTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Steward\Console\Command\Fixtures\ParallelTests;
+
+use Lmc\Steward\Component\Legacy;
+use Lmc\Steward\Test\AbstractTestCase;
+
+class FirstTest extends AbstractTestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testMethod1(): void
+    {
+    }
+}

--- a/src-tests/Console/Command/Fixtures/ParallelTests/SecondTest.php
+++ b/src-tests/Console/Command/Fixtures/ParallelTests/SecondTest.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Steward\Console\Command\Fixtures\ParallelTests;
+
+use Lmc\Steward\Test\AbstractTestCase;
+
+class SecondTest extends AbstractTestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testMethod1(): void
+    {
+    }
+}

--- a/src-tests/Console/Command/Fixtures/ParallelTests/TestDependingOnFirstTest.php
+++ b/src-tests/Console/Command/Fixtures/ParallelTests/TestDependingOnFirstTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Steward\Console\Command\Fixtures\ParallelTests;
+
+use Lmc\Steward\Test\AbstractTestCase;
+
+/**
+ * @delayAfter Lmc\Steward\Console\Command\Fixtures\ParallelTests\FirstTest
+ * @delayMinutes 0
+ */
+class TestDependingOnFirstTest extends AbstractTestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testMethod1(): void
+    {
+    }
+}

--- a/src-tests/Console/Command/Fixtures/ParallelTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/ParallelTests/expected-debug-output.txt
@@ -1,0 +1,18 @@
+%A
+Parallel limit: 1
+%A
+Testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\FirstTest" is prepared to be run
+Max parallel limit reached, testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\SecondTest" is queued
+Testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\TestDependingOnFirstTest" is queued to be run 0.0 minutes after testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\FirstTest" is finished
+%A
+[%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\FirstTest" started%A
+%A
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\FirstTest" (result: passed, time: %f sec)
+[%s] Dequeing testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\SecondTest" which was queued because of parallel limit
+%A
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\SecondTest" (result: passed, time: %f sec)
+[%s] Dequeing testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\TestDependingOnFirstTest"
+%A
+[%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\ParallelTests\TestDependingOnFirstTest" (result: passed, time: %f sec)%A
+[%s] All testcases done in %f seconds
+%A[OK] Testcases executed: 3 (passed: 3)%A

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
@@ -35,7 +35,7 @@ Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s] [WebDriver] Ex
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> [%s] --- Finished execution of test "testWebpage" ---%A
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest> OK (1 test, 1 assertion)%A
 [%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed, time: %f sec)%A
-[%s] Unqueing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
+[%s] Dequeing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" started with command:
 '%s/steward/bin/phpunit-steward' '--log-junit=%s/logs/Lmc-Steward-Console-Command-Fixtures-SimpleTests-DependantTest.xml' '--configuration=%s/phpunit.xml' '%s/DependantTest.php'
 Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest> [%s] Registering test results publisher "Lmc\Steward\Publisher\XmlPublisher"%a

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-debug-output.txt
@@ -3,6 +3,7 @@ Browser: chrome
 Environment: staging
 Path to logs: %s/logs
 Ignore delays: no
+Parallel limit: 50
 Selenium server (hub) url: %s, trying connection...OK
 Searching for testcases:
  - in directory "%s/src-tests/Console/Command/Fixtures/SimpleTests"

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
@@ -12,7 +12,7 @@ Starting execution of testcases
 -------------------------------
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" started%A
 [%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\SimpleTest" (result: passed, time: %f sec)%A
-[%s] Unqueing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
+[%s] Dequeing testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest"%A
 [%s] Execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" started%A
 [%s] Finished execution of testcase "Lmc\Steward\Console\Command\Fixtures\SimpleTests\DependantTest" (result: passed, time: %f sec)
 [%s] Waiting (running: 0, queued: 0, done: 2 [passed: 2])

--- a/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
+++ b/src-tests/Console/Command/Fixtures/SimpleTests/expected-very-verbose-output.txt
@@ -3,6 +3,7 @@ Browser: chrome
 Environment: staging
 Path to logs: %s/logs
 Ignore delays: no
+Parallel limit: 50
 Selenium server (hub) url: %s, trying connection...OK
 Searching for testcases:
  - in directory "%s/src-tests/Console/Command/Fixtures/SimpleTests"

--- a/src-tests/Console/Command/RunCommandIntegrationTest.php
+++ b/src-tests/Console/Command/RunCommandIntegrationTest.php
@@ -92,6 +92,26 @@ class RunCommandIntegrationTest extends TestCase
         ];
     }
 
+    public function testShouldExecuteTestsWithParallelLimit(): void
+    {
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
+                'environment' => 'staging',
+                'browser' => 'chrome',
+                '--tests-dir' => __DIR__ . '/Fixtures/ParallelTests',
+                '--parallel-limit' => 1,
+            ],
+            ['verbosity' => OutputInterface::VERBOSITY_DEBUG]
+        );
+
+        $output = $this->tester->getDisplay();
+
+        $this->assertStringMatchesFormatFile(__DIR__ . '/Fixtures/ParallelTests/expected-debug-output.txt', $output);
+
+        $this->assertSame(0, $this->tester->getStatusCode());
+    }
+
     public function testShouldExecuteTestsThatDontNeedBrowser(): void
     {
         $this->tester->execute(

--- a/src-tests/Process/ExecutionLoopTest.php
+++ b/src-tests/Process/ExecutionLoopTest.php
@@ -27,9 +27,10 @@ class ExecutionLoopTest extends TestCase
         );
 
         $result = $loop->start();
+        $output = $outputBuffer->fetch();
 
-        $this->assertTrue($result);
-        $this->assertContains('[OK] Testcases executed: 0', $outputBuffer->fetch());
+        $this->assertTrue($result, 'Exception loop did not finish successfully, output was: ' . "\n" . $output);
+        $this->assertContains('[OK] Testcases executed: 0', $output);
     }
 
     /** @test */
@@ -55,9 +56,9 @@ class ExecutionLoopTest extends TestCase
         );
 
         $result = $loop->start();
-        $this->assertTrue($result);
-
         $output = $outputBuffer->fetch();
+
+        $this->assertTrue($result, 'Exception loop did not finish successfully, output was: ' . "\n" . $output);
 
         $this->assertContains('Testcase "NoDelay" is prepared to be run', $output);
         $this->assertContains(

--- a/src-tests/Process/ExecutionLoopTest.php
+++ b/src-tests/Process/ExecutionLoopTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
 
 /**
  * @covers \Lmc\Steward\Process\ExecutionLoop
@@ -17,17 +18,53 @@ class ExecutionLoopTest extends TestCase
     public function shouldExecuteEmptyProcessSet(): void
     {
         $emptyProcessSet = new ProcessSet();
-        $output = new BufferedOutput(OutputInterface::VERBOSITY_DEBUG);
+        $outputBuffer = new BufferedOutput(OutputInterface::VERBOSITY_DEBUG);
 
         $loop = new ExecutionLoop(
             $emptyProcessSet,
-            new StewardStyle(new StringInput(''), $output),
+            new StewardStyle(new StringInput(''), $outputBuffer),
             new MaxTotalDelayStrategy()
         );
 
         $result = $loop->start();
 
         $this->assertTrue($result);
-        $this->assertContains('[OK] Testcases executed: 0', $output->fetch());
+        $this->assertContains('[OK] Testcases executed: 0', $outputBuffer->fetch());
+    }
+
+    /** @test */
+    public function shouldDequeueProcessesWithoutDelayOnStartup(): void
+    {
+        $noDelayTest = new ProcessWrapper(new Process('echo NoDelay'), 'NoDelay');
+        $delayedTest = new ProcessWrapper(new Process('echo Delayed'), 'Delayed');
+        $delayedTest->setDelay('NoDelay', 0.001);
+
+        $processSet = new ProcessSet();
+        $processSet->add($noDelayTest);
+        $processSet->add($delayedTest);
+
+        // Preconditions - both processes should be queued after being added
+        $processes = $processSet->get(ProcessWrapper::PROCESS_STATUS_QUEUED);
+        $this->assertCount(2, $processes);
+
+        $outputBuffer = new BufferedOutput(OutputInterface::VERBOSITY_DEBUG);
+        $loop = new ExecutionLoop(
+            $processSet,
+            new StewardStyle(new StringInput(''), $outputBuffer),
+            new MaxTotalDelayStrategy()
+        );
+
+        $result = $loop->start();
+        $this->assertTrue($result);
+
+        $output = $outputBuffer->fetch();
+
+        $this->assertContains('Testcase "NoDelay" is prepared to be run', $output);
+        $this->assertContains(
+            'Testcase "Delayed" is queued to be run 0.0 minutes after testcase "NoDelay" is finished',
+            $output
+        );
+
+        $this->assertContains('Dequeing testcase "Delayed"', $output);
     }
 }

--- a/src-tests/Process/ProcessSetTest.php
+++ b/src-tests/Process/ProcessSetTest.php
@@ -7,8 +7,6 @@ use Graphp\Algorithms\Tree\OutTree;
 use Lmc\Steward\Process\Fixtures\MockOrderStrategy;
 use Lmc\Steward\Publisher\XmlPublisher;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Process\Process;
 
 class ProcessSetTest extends TestCase
@@ -193,40 +191,6 @@ class ProcessSetTest extends TestCase
                 ProcessWrapper::PROCESS_RESULT_FATAL => 1,
             ],
             $this->set->countResults()
-        );
-    }
-
-    public function testShouldDequeueProcessesWithoutDelay(): void
-    {
-        $noDelayTest = new ProcessWrapper(new Process(''), 'NoDelay');
-        $delayedTest = new ProcessWrapper(new Process(''), 'Delayed');
-        $delayedTest->setDelay('NoDelay', 3.3);
-        $this->set->add($noDelayTest);
-        $this->set->add($delayedTest);
-        $outputBuffer = new BufferedOutput(Output::VERBOSITY_DEBUG);
-
-        // Preconditions - both processes should be queued after being added
-        $processes = $this->set->get(ProcessWrapper::PROCESS_STATUS_QUEUED);
-        $this->assertCount(2, $processes);
-
-        // Should Dequeue process without delay
-        $this->set->dequeueProcessesWithoutDelay($outputBuffer);
-
-        // The process without delay should be prepared now
-        $prepared = $this->set->get(ProcessWrapper::PROCESS_STATUS_PREPARED);
-        $this->assertCount(1, $prepared);
-        $this->assertSame($noDelayTest, $prepared['NoDelay']);
-
-        // The other process with delay should be kept as queued
-        $queued = $this->set->get(ProcessWrapper::PROCESS_STATUS_QUEUED);
-        $this->assertCount(1, $queued);
-        $this->assertSame($delayedTest, $queued['Delayed']);
-
-        $output = $outputBuffer->fetch();
-        $this->assertContains('Testcase "NoDelay" is prepared to be run', $output);
-        $this->assertContains(
-            'Testcase "Delayed" is queued to be run 3.3 minutes after testcase "NoDelay" is finished',
-            $output
         );
     }
 

--- a/src/Process/ProcessSet.php
+++ b/src/Process/ProcessSet.php
@@ -7,7 +7,6 @@ use Fhaculty\Graph\Graph;
 use Fhaculty\Graph\Vertex;
 use Graphp\Algorithms\Tree\OutTree;
 use Lmc\Steward\Publisher\AbstractPublisher;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Set of Test processes.
@@ -92,36 +91,6 @@ class ProcessSet implements \Countable
         }
 
         return $return;
-    }
-
-    /**
-     * Set queued processes without delay as prepared
-     *
-     * @param OutputInterface $output Where list of dequeued and queued processes will be printed
-     */
-    public function dequeueProcessesWithoutDelay(OutputInterface $output): void
-    {
-        $queuedProcesses = $this->get(ProcessWrapper::PROCESS_STATUS_QUEUED);
-
-        foreach ($queuedProcesses as $className => $processWrapper) {
-            if (!$processWrapper->isDelayed()) {
-                $output->writeln(
-                    sprintf('Testcase "%s" is prepared to be run', $className),
-                    OutputInterface::VERBOSITY_DEBUG
-                );
-                $processWrapper->setStatus(ProcessWrapper::PROCESS_STATUS_PREPARED);
-            } else {
-                $output->writeln(
-                    sprintf(
-                        'Testcase "%s" is queued to be run %01.1f minutes after testcase "%s" is finished',
-                        $className,
-                        $processWrapper->getDelayMinutes(),
-                        $processWrapper->getDelayAfter()
-                    ),
-                    OutputInterface::VERBOSITY_DEBUG
-                );
-            }
-        }
     }
 
     /**

--- a/src/Publisher/AbstractPublisher.php
+++ b/src/Publisher/AbstractPublisher.php
@@ -51,6 +51,8 @@ abstract class AbstractPublisher
         BaseTestRunner::STATUS_ERROR => self::TEST_RESULT_BROKEN,
         BaseTestRunner::STATUS_RISKY => self::TEST_RESULT_BROKEN,
         BaseTestRunner::STATUS_WARNING => self::TEST_RESULT_BROKEN,
+        // @todo Remove after https://github.com/sebastianbergmann/phpunit/issues/3379 is fixed
+        BaseTestRunner::STATUS_UNKNOWN => self::TEST_RESULT_SKIPPED,
     ];
 
     /**


### PR DESCRIPTION
Ref. #210, #153 

Allow to define a parallel limit (by default 50) - the actual number of parallel processes started by Steward.

Current theory of operation was:
1. start separate system process for **each** testace class (except those with delay)
2. start PHPUnit in each process and let it connect to Selenium server
3. use Selenium queue capabilities (ie. wait with open connection until Selenium session is created)
4. run the test

But this started causing issues on large testsuites (with hundreds of tests), because, obviously, there has been running system process (consuming RAM, CPU) for each testcase, even if most of them were just queued and were just waiting for free slot. And with Selenium farm, which is capable of running many tests in a parallel, this could easily lead to uncontrolled resources exhausting.

The new theory operation is:
1. start separate system process for testace class until parallel limit is reached
2. any new process will be started only after some of the previously started processes finishes (and the number of parallel processes is below the limit)

Note the PR is still kind-of proof of concept, I expect some beta-testing of this branch (and maybe some code cleanup) before this will be merged to master.