### PR TITLE
Revert readiness check, as it would prevent queuing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 <!-- There is always Unreleased section on the top. Subsections (Added, Changed, Fixed, Removed) should be added as needed. -->
 
 ## Unreleased
-### Added
-- Detect readiness state of new Selenium servers (v3.5.3+ running in W3C-protocol mode) during startup, so that eg. no available Selenium server nodes are reported before attempting to start any test.
-
 ### Changed
 - Require PHP 7.1+ and Symfony 4 components.
 - Update to namespaced PHPUnit 7.0.

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -134,18 +134,6 @@ class SeleniumServerAdapterTest extends TestCase
         $this->assertEquals('error reading server response', $this->adapter->getLastError());
     }
 
-    public function testShouldDetectNotReadySeleniumServer(): void
-    {
-        $notReadyResponse = file_get_contents(__DIR__ . '/Fixtures/response-standalone-w3c-not-ready.json');
-        $fileGetContentsMock = $this->getFunctionMock(__NAMESPACE__, 'file_get_contents');
-        $fileGetContentsMock->expects($this->once())
-            ->with($this->serverUrl . '/status')
-            ->willReturn($notReadyResponse);
-
-        $this->assertFalse($this->adapter->isSeleniumServer());
-        $this->assertEquals('server is not ready ("No spare hub capacity")', $this->adapter->getLastError());
-    }
-
     public function testShouldReturnJsonErrorDescriptionIfTheServerResponseIsNotJson(): void
     {
         $fileGetContentsMock = $this->getFunctionMock(__NAMESPACE__, 'file_get_contents');
@@ -181,6 +169,10 @@ class SeleniumServerAdapterTest extends TestCase
         return [
             // $responseData, $expectedCloudService
             'standalone W3C server (in ready state)' => [__DIR__ . '/Fixtures/response-standalone-w3c-ready.json', ''],
+            'standalone W3C server (in not ready state - but tests could wait in queue)' => [
+                __DIR__ . '/Fixtures/response-standalone-w3c-not-ready.json',
+                '',
+            ],
             'standalone server v2' => [__DIR__ . '/Fixtures/response-standalone-v2.json', ''],
             'standalone local grid v2' => [__DIR__ . '/Fixtures/response-standalone-hub-v2.json', ''],
             'Sauce Labs cloud' =>

--- a/src/Selenium/SeleniumServerAdapter.php
+++ b/src/Selenium/SeleniumServerAdapter.php
@@ -104,15 +104,6 @@ class SeleniumServerAdapter
             return false;
         }
 
-        // Try to get readiness status from W3C protocol conforming implementations
-        if (isset($decodedData->value, $decodedData->value->ready, $decodedData->value->message)) {
-            if (!$decodedData->value->ready) {
-                $this->lastError = 'server is not ready ("' . $decodedData->value->message . '")';
-
-                return false;
-            }
-        }
-
         $this->cloudService = $this->detectCloudServiceByStatus($decodedData);
 
         return true;


### PR DESCRIPTION
This partially reverts commit 447202293853515df88846d373d6f404f55e64ca.

Readiness [actually means](https://www.w3.org/TR/webdriver1/#dfn-readiness-state) there is some hub ready to execute the tests. But if there are not, tests should just wait in the queue, and Steward should not reject to start them. So this check should be removed.