### PR TITLE
Do not start browser for skipped tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Remote server running in W3C-protocol mode (eg. Selenium v3.5.3+) was erroneously detected as BrowserStack cloud service.
 - `--xdebug` option did not have any effect unless passed as the last option.
 - Properly auto-detect port 443 (not 80) when https server URL is used as `--server-url`.
+- Do not start browser for test skipped because it was depending on some already failed test (using `@depends` annotation).
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-filter": "*",
         "ext-SimpleXML": "*",
         "ext-libxml": "*",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "7.4.x-dev",
         "symfony/console": "^4.0",
         "symfony/process": "^4.0 !=4.0.2",
         "symfony/finder": "^4.0",
@@ -55,7 +55,7 @@
         "ondram/ci-detector": "^3.0"
     },
     "require-dev": {
-        "php-mock/php-mock-phpunit": "^2.1.0",
+        "php-mock/php-mock-phpunit": "^2.1.2",
         "phpunit/php-code-coverage": "^6.0",
         "php-coveralls/php-coveralls": "^2.0",
         "symfony/var-dumper": "^4.0",

--- a/src-tests/Console/Command/Fixtures/SkippedTests/SkippedTest.php
+++ b/src-tests/Console/Command/Fixtures/SkippedTests/SkippedTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Steward\Console\Command\Fixtures\SkippedTests;
+
+use Lmc\Steward\Test\AbstractTestCase;
+
+class SkippedTest extends AbstractTestCase
+{
+    public function testWhichFails(): void
+    {
+        $this->fail();
+    }
+
+    /**
+     * @depends testWhichFails
+     */
+    public function testsWhichShouldBeSkipped(): void
+    {
+    }
+}

--- a/src-tests/Console/Command/RunCommandIntegrationTest.php
+++ b/src-tests/Console/Command/RunCommandIntegrationTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * Run command tests that require real Selenium server to execute the tests.
  *
  * @covers \Lmc\Steward\Console\Command\RunCommand
+ * @covers \Lmc\Steward\Listener\WebDriverListener
  * @covers \Lmc\Steward\Process\ExecutionLoop
  * @group integration
  * @runTestsInSeparateProcesses
@@ -157,5 +158,20 @@ class RunCommandIntegrationTest extends TestCase
         );
 
         $this->assertSame(0, $this->tester->getStatusCode());
+    }
+
+    public function testShouldNotStartBrowserForSkippedTests(): void
+    {
+        $this->tester->execute(
+            [
+                'command' => $this->command->getName(),
+                'environment' => 'staging',
+                'browser' => 'chrome',
+                '--tests-dir' => __DIR__ . '/Fixtures/SkippedTests',
+            ],
+            ['verbosity' => OutputInterface::VERBOSITY_DEBUG]
+        );
+
+        $this->assertSame(1, mb_substr_count($this->tester->getDisplay(), 'Initializing "chrome" WebDriver'));
     }
 }

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
 use PHPUnit\Framework\WarningTestCase;
+use PHPUnit\Runner\BaseTestRunner;
 
 /**
  * Listener for initialization and destruction of WebDriver before and after each test.
@@ -58,6 +59,10 @@ class WebDriverListener implements TestListener
 
         if (!$test instanceof AbstractTestCase) {
             throw new \InvalidArgumentException('Test case must be descendant of Lmc\Steward\Test\AbstractTestCase');
+        }
+
+        if ($test->getStatus() === BaseTestRunner::STATUS_SKIPPED) {
+            return;
         }
 
         // Initialize NullWebDriver if self::NO_BROWSER_ANNOTATION is used on testcase class or test method


### PR DESCRIPTION
Fixes #154 .

This could be fixed thanks to https://github.com/sebastianbergmann/phpunit/issues/3379 . It now depends on yet unreleased PHPUnit 7.4.4.

This will help to fail the tests faster - ie. you will know your test suite is broken sooner, as Steward will now not initialize empty browser window for those skipped tests.