### PR TITLE
Properly detect port of https server URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 - Remote server running in W3C-protocol mode (eg. Selenium v3.5.3+) was erroneously detected as BrowserStack cloud service.
 - `--xdebug` option did not have any effect unless passed as the last option.
+- Properly auto-detect port 443 (not 80) when https server URL is used as `--server-url`.
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/src-tests/Selenium/SeleniumServerAdapterTest.php
+++ b/src-tests/Selenium/SeleniumServerAdapterTest.php
@@ -57,10 +57,14 @@ class SeleniumServerAdapterTest extends TestCase
             'trailing slash should be removed' => ['http://localhost:4444/wd/hub/', 'http://localhost:4444/wd/hub'],
             'local URL with specified port should keep it' => ['http://localhost:4444', 'http://localhost:4444'],
             'local URL without port should use 4444' => ['http://localhost', 'http://localhost:4444'],
+            'HTTPS URL without port should use 443' => ['https://foo.bar', 'https://foo.bar:443'],
+            'HTTPS on different port than 443' => ['https://foo.bar:666', 'https://foo.bar:666'],
             'cloud service URL with port should keep it' =>
                 ['http://foo:bar@ondemand.saucelabs.com:1337', 'http://foo:bar@ondemand.saucelabs.com:1337'],
             'Sauce Labs cloud service without port should use 80' =>
                 ['http://foo:bar@ondemand.saucelabs.com', 'http://foo:bar@ondemand.saucelabs.com:80'],
+            'Sauce Labs HTTPS cloud service without port should use 443' =>
+                ['https://foo:bar@ondemand.saucelabs.com', 'https://foo:bar@ondemand.saucelabs.com:443'],
             'BrowserStack cloud service without port should use 80' =>
                 ['http://foo:bar@hub-cloud.browserstack.com', 'http://foo:bar@hub-cloud.browserstack.com:80'],
             'TestingBot cloud service without port should use 80' =>
@@ -68,9 +72,9 @@ class SeleniumServerAdapterTest extends TestCase
             'non-cloud URL without port should use 4444' => ['http://foo.com', 'http://foo.com:4444'],
             'username and host should get default port' => ['http://user@foo', 'http://user@foo:4444'],
             'all url parts' =>
-                ['https://user:pass@host:1337/wd/hub?foo=bar', 'https://user:pass@host:1337/wd/hub?foo=bar'],
+                ['http://user:pass@host:1337/wd/hub?foo=bar', 'http://user:pass@host:1337/wd/hub?foo=bar'],
             'all parts expects port should get default port' =>
-                ['https://user:pass@host/wd/hub?foo=bar', 'https://user:pass@host:4444/wd/hub?foo=bar'],
+                ['http://user:pass@host/wd/hub?foo=bar', 'http://user:pass@host:4444/wd/hub?foo=bar'],
         ];
     }
 

--- a/src/Selenium/SeleniumServerAdapter.php
+++ b/src/Selenium/SeleniumServerAdapter.php
@@ -17,6 +17,7 @@ class SeleniumServerAdapter
     protected const HUB_ENDPOINT = '/wd/hub';
     protected const DEFAULT_PORT = 4444;
     protected const DEFAULT_PORT_CLOUD_SERVICE = 80;
+    protected const DEFAULT_PORT_CLOUD_SERVICE_HTTPS = 443;
 
     /** @var array */
     protected $serverUrlParts;
@@ -165,7 +166,7 @@ class SeleniumServerAdapter
         }
 
         if (empty($urlParts['port'])) {
-            $urlParts['port'] = $this->guessPort($urlParts['host']);
+            $urlParts['port'] = $this->guessPort($urlParts['host'], $urlParts['scheme']);
         }
 
         return $urlParts;
@@ -174,8 +175,12 @@ class SeleniumServerAdapter
     /**
      * Guess port for given service
      */
-    protected function guessPort(string $host): int
+    protected function guessPort(string $host, string $scheme): int
     {
+        if ($scheme === 'https') {
+            return self::DEFAULT_PORT_CLOUD_SERVICE_HTTPS;
+        }
+
         foreach (['saucelabs.com', 'browserstack.com', 'testingbot.com'] as $knownCloudHost) {
             if (mb_strpos($host, $knownCloudHost) !== false) {
                 return self::DEFAULT_PORT_CLOUD_SERVICE;


### PR DESCRIPTION
Fixes #179.

Any https server-url without port will now use port 443.