### PR TITLE
DX: Travis - drop --ignore-platform-reqs flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
     - php: 7.1
       env: dependencies="--prefer-lowest --prefer-stable"
     - php: 7.3
-      env: dependencies="--ignore-platform-reqs"
     - php: 7.2
       env: CHECK_CODESTYLE=1
       before_install:


### PR DESCRIPTION
ref #230

PHP CS Fixer v2.14 officially supports PHP 7.3 now