### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.github export-ignore
+/logs export-ignore
+/src-tests export-ignore
+/tests export-ignore
+/.appveyor.yml export-ignore
+/.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-
+/easy-coding-standard.yaml export-ignore
+/phpstan.neon export-ignore


### PR DESCRIPTION
Export-ignore needs for optimizing the traffic when it package downloads via composer. Next files and directories will be ignored and will not download.