### PR TITLE
update server-url documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ There is also a bunch of useful options for the `run` command:
 
 - `--group` - only run specific group(s) of tests
 - `--exclude-group` - exclude some group(s) of tests (can be even combined with `--group`)
-- `--server-url` - set different url of selenium server than the default (which is `http://localhost:4444/wd/hub`)
+- `--server-url` - set different url of selenium server than the default (which is `http://localhost:4444`)
 - `--xdebug` - start Xdebug debugger on your tests. Allows you to debug tests from your IDE ([learn more about tests debugging][wiki-debugging] in our Wiki)
 - `--capability` - directly pass any extra capability to the Selenium WebDriver server ([see wiki][wiki-capabilities] for more information and examples)
 - `--parallel-limit` - limit number of testcases being executed in a parallel (default is 50)


### PR DESCRIPTION
This is what it looks like after running
```
./vendor/bin/steward run --help
```

```
[...]
--server-url=SERVER-URL        Selenium server (hub) URL (may include port numbe) [default: "http://localhost:4444"]
```

I wasted a little more time than I care to admit today trying to figure out why I couldn't communicate with my hub, until I spotted that the `/wd/hub/` part should not be part of the url