### PR TITLE
Require PHPUnit ^8.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 - Require PHP 7.2+ and Symfony 4 components.
-- Update to namespaced PHPUnit 7.0.
+- Update to namespaced PHPUnit. Set minimal required version to PHPUnit 8.5.12.
 - Use php-webdriver 1.8+ with W3C WebDriver support.
 - Methods now uses strict type-hints and return type-hints. Inherited classes and interfaces (eg. `CustomCapabilitiesResolverInterface`, `OptimizeOrderInterface` etc.) may require to be changed in accordance with this.
 - Simplified and improved test output.

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ondram/ci-detector": "^3.1",
         "php-webdriver/webdriver": "^1.8.1",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "phpunit/phpunit": "^7.5.20",
+        "phpunit/phpunit": "^8.5.12",
         "roave/better-reflection": "^4.3",
         "symfony/console": "^4.0",
         "symfony/event-dispatcher": "^4.0",
@@ -56,7 +56,6 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.11",
         "phpstan/phpstan-phpunit": "^0.12.6",
-        "phpunit/php-code-coverage": "^6.0",
         "symfony/var-dumper": "^4.0"
     },
     "suggest": {

--- a/src-tests/Console/Command/RunCommandTest.php
+++ b/src-tests/Console/Command/RunCommandTest.php
@@ -408,7 +408,7 @@ class RunCommandTest extends TestCase
 
         $seleniumAdapterMock->expects($this->any())
             ->method('getLastError')
-            ->willReturn(null);
+            ->willReturn('');
 
         $seleniumAdapterMock->expects($this->any())
             ->method('isSeleniumServer')

--- a/src-tests/Listener/SnapshotListenerTest.php
+++ b/src-tests/Listener/SnapshotListenerTest.php
@@ -111,7 +111,7 @@ class SnapshotListenerTest extends TestCase
                 $dummyException,
                 'FooBarTest',
                 'testFooBar',
-                0,
+                '0',
                 ['foo', 'bar'],
                 'FooBarTest-testFooBar-with-data-set-0',
             ],

--- a/src-tests/MockAbstractTestCaseWithNameTrait.php
+++ b/src-tests/MockAbstractTestCaseWithNameTrait.php
@@ -3,8 +3,8 @@
 namespace Lmc\Steward;
 
 use Lmc\Steward\Test\AbstractTestCase;
-use PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 
 trait MockAbstractTestCaseWithNameTrait
 {

--- a/src-tests/Selenium/CapabilitiesResolverTest.php
+++ b/src-tests/Selenium/CapabilitiesResolverTest.php
@@ -78,7 +78,7 @@ class CapabilitiesResolverTest extends TestCase
             ]
         );
 
-        $ciMock = $this->createConfiguredMock(Jenkins::class, ['getBuildNumber' => 1337, 'getCiName' => 'Jenkins']);
+        $ciMock = $this->createConfiguredMock(Jenkins::class, ['getBuildNumber' => '1337', 'getCiName' => 'Jenkins']);
         $ciDetectorMock = $this->createConfiguredMock(
             CiDetector::class,
             ['isCiDetected' => true, 'detect' => $ciMock]


### PR DESCRIPTION
Require PHPUnit 8.5.12 (it also has PHP 8 support!).

Part of #260 .