### PR TITLE
Workaround for Geckodriver session closing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Properly auto-detect port 443 (not 80) when https server URL is used as `--server-url`.
 - Do not start browser for test skipped because it was depending on some already failed test (using `@depends` annotation).
 - Parsing of the latest Selenium server version in `install` command.
+- Do not print `Error closing the session, browser may died.` after Firefox closes the error.
 
 ### Removed
 - `TestUtils` class which was already deprecated in 2.1.

--- a/src/Listener/WebDriverListener.php
+++ b/src/Listener/WebDriverListener.php
@@ -5,6 +5,7 @@ namespace Lmc\Steward\Listener;
 use Facebook\WebDriver\Exception\SessionNotCreatedException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\WebDriverBrowserType;
 use Lmc\Steward\ConfigProvider;
 use Lmc\Steward\Selenium\CapabilitiesResolver;
 use Lmc\Steward\Test\AbstractTestCase;
@@ -124,7 +125,12 @@ class WebDriverListener implements TestListener
                 $test->wd->close();
                 $test->wd->quit();
             } catch (WebDriverException $e) {
-                $test->warn('Error closing the session, browser may died.');
+                // Geckodriver always throw error when closing the session. We ignore it to not pollute the output.
+                // https://github.com/mozilla/geckodriver/issues/732, https://bugzilla.mozilla.org/show_bug.cgi?id=1403510
+                if (ConfigProvider::getInstance()->browserName !== WebDriverBrowserType::FIREFOX
+                    || $e->getMessage() !== 'invalid session id') {
+                    $test->warn('Error closing the session, browser may died.');
+                }
             } finally {
                 $output = ob_get_clean();
                 $test->appendFormattedTestLog($output);


### PR DESCRIPTION
Do not print exception after Firefox session was closed.

This is workaround for Geckodriver bug https://github.com/mozilla/geckodriver/issues/732

What appears in the Steward log:
```
My\TitlePageTest> [2021-03-04 18:52:31] Destroying "firefox" WebDriver for session "66f0dd44-820a-4ef3-8e79-84faf4c71333"
My\TitlePageTest> [2021-03-04 18:52:31] [WebDriver] Executing command "close" with params []
My\TitlePageTest> [2021-03-04 18:52:31] [WebDriver] Executing command "quit" with params []
My\TitlePageTest> [2021-03-04 18:52:31] [WARN] Error closing the session, browser may died.
```