### PR TITLE
Fix invalid class annotations causing fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+### Fixed
+- Invalid class annotation could cause fatal error when parsing tests.
+
 ## 3.0.0 - 2021-12-02
 
 ### Added

--- a/src-tests/Utils/Annotations/ClassAnnotationsTest.php
+++ b/src-tests/Utils/Annotations/ClassAnnotationsTest.php
@@ -53,6 +53,7 @@ class ClassAnnotationsTest extends TestCase
                     'first' => ['First value', 'Second value of first'],
                     'second' => ['Second value'],
                     'third' => ['Third "special" value'],
+                    'see' => [''],
                 ],
             ],
             'Class with mixed key-only and key-value annotations' => [

--- a/src-tests/Utils/Annotations/Fixtures/ClassKeyValueAnnotations.php
+++ b/src-tests/Utils/Annotations/Fixtures/ClassKeyValueAnnotations.php
@@ -7,6 +7,7 @@ namespace Lmc\Steward\Utils\Annotations\Fixtures;
  * @second Second value
  * @third Third "special" value
  * @first Second value of first
+ * @see FOO-BAR This makes phpDocumentor to return InvalidTag instance
  */
 class ClassKeyValueAnnotations
 {

--- a/src/Utils/Annotations/ClassAnnotations.php
+++ b/src/Utils/Annotations/ClassAnnotations.php
@@ -48,10 +48,9 @@ class ClassAnnotations
 
         $annotations = [];
 
-        /** @var BaseTag $tag */
         foreach ($docBlock->getTags() as $tag) {
             $annotationToAdd = '';
-            if ($tag->getDescription() !== null) {
+            if ($tag instanceof BaseTag && $tag->getDescription() !== null) {
                 $annotationToAdd = $tag->getDescription()->getBodyTemplate();
             }
 


### PR DESCRIPTION
Annotations in form FOO-BAR makes phpDocumentor retuning InvalidTag instead of BaseTag, causing fatal error in steward annotation parsing.
