### PR TITLE
Read and store URL of executor node also on Selenium 4

### DIFF
--- a/src-tests/Publisher/XmlPublisherTest.php
+++ b/src-tests/Publisher/XmlPublisherTest.php
@@ -302,10 +302,10 @@ class XmlPublisherTest extends TestCase
     }
 
     /**
-     * @dataProvider provideEndpointTestsessionResponse
+     * @dataProvider provideServerGraphQlResponse
      */
     public function testShouldLogTestExecutorWhenTestStarted(
-        string $testsessionEndpointResponse,
+        string $serverResponse,
         ?string $expectedExecutor
     ): void {
         $webDriverMock = $this->createMock(RemoteWebDriver::class);
@@ -317,9 +317,12 @@ class XmlPublisherTest extends TestCase
         $testMock->wd = $webDriverMock;
 
         $fileGetContentsMock = $this->getFunctionMock('Lmc\Steward\Selenium', 'file_get_contents');
-        $fileGetContentsMock->expects($this->once())
-            ->with('http://server.tld:4444/grid/api/testsession?session=session-id-foo-bar')
-            ->willReturn($testsessionEndpointResponse);
+        $fileGetContentsMock->expects($this->at(0))
+            ->with('http://server.tld:4444/graphql')
+            ->willReturn('{"data": {"__typename": "GridQuery"}}');
+        $fileGetContentsMock->expects($this->at(1))
+            ->with('http://server.tld:4444/graphql')
+            ->willReturn($serverResponse);
 
         $fileName = $this->createEmptyFile();
 
@@ -341,12 +344,12 @@ class XmlPublisherTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideEndpointTestsessionResponse(): array
+    public function provideServerGraphQlResponse(): array
     {
         return [
             'executor found' => [
-                file_get_contents(__DIR__ . '/../Selenium/Fixtures/testsession-found.json'),
-                'http://10.1.255.241:5555',
+                file_get_contents(__DIR__ . '/../Selenium/Fixtures/graphql-response-found.json'),
+                'http://10.216.10.116:5555',
             ],
             'empty response' => ['', null],
         ];

--- a/src-tests/Selenium/Fixtures/graphql-response-found.json
+++ b/src-tests/Selenium/Fixtures/graphql-response-found.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "session": {
+      "id": "4f1bebc2-667e-4b99-b16a-ff36221a20b3",
+      "nodeId": "9ae55dd1-8dcd-4cbf-81fb-fc144ab3d90e",
+      "nodeUri": "http:\u002f\u002f10.216.10.116:5555"
+    }
+  }
+}

--- a/src-tests/Selenium/Fixtures/graphql-response-invalid.txt
+++ b/src-tests/Selenium/Fixtures/graphql-response-invalid.txt
@@ -1,0 +1,1 @@
+Invalid GraphQL response

--- a/src-tests/Selenium/Fixtures/graphql-response-not-found.json
+++ b/src-tests/Selenium/Fixtures/graphql-response-not-found.json
@@ -1,0 +1,21 @@
+{
+  "errors": [
+    {
+      "message": "Exception while fetching data (\u002fsession) : No ongoing session found with the requested session id.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 3
+        }
+      ],
+      "path": [
+        "session"
+      ],
+      "extensions": {
+        "sessionId": "4f1bebc2-667e-4b99-b16a-ff36221a20b3",
+        "classification": "DataFetchingException"
+      }
+    }
+  ],
+  "data": null
+}

--- a/src/Exception/CommandException.php
+++ b/src/Exception/CommandException.php
@@ -5,7 +5,7 @@ namespace Lmc\Steward\Exception;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 
 /**
- * Runtime exception from Steward Command (ie. wrong CLI arguments).
+ * Runtime exception from Steward Command (e.g. wrong CLI arguments).
  * It also implements `Symfony\Component\Console\Exception\ExceptionInterface` to not break Symfony Command behavior.
  */
 class CommandException extends \RuntimeException implements ExceptionInterface, StewardExceptionInterface


### PR DESCRIPTION
With Selenium 4, the generated timeline was unusable when tests were run on multiple Selenium nodes - because Steward was unable to read which node run which tests.

Selenium 4 removed the previous REST /testsession endpoint which was used for this. However, it introduced new GraphQL endpoint to query various metadata, which we can now use for this case.